### PR TITLE
[refactor] 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
@@ -2,6 +2,8 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -20,6 +22,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class ComDefaultCodeVO implements Serializable {
     /**
 	 *  serialVersion UID
@@ -28,157 +32,24 @@ public class ComDefaultCodeVO implements Serializable {
 
 	/** 코드 ID */
     private String codeId = "";
-    
+
     /** 상세코드 */
     private String code = "";
-    
+
     /** 코드명 */
     private String codeNm = "";
-    
+
     /** 코드설명 */
     private String codeDc = "";
-    
+
     /** 특정테이블명 */
     private String tableNm = "";	//특정테이블에서 코드정보를추출시 사용
-    
+
     /** 상세 조건 여부 */
     private String haveDetailCondition = "N";
-    
+
     /** 상세 조건 */
     private String detailCondition = "";
-    
-    /**
-     * codeId attribute를 리턴한다.
-     * 
-     * @return the codeId
-     */
-    public String getCodeId() {
-	return codeId;
-    }
-
-    /**
-     * codeId attribute 값을 설정한다.
-     * 
-     * @param codeId
-     *            the codeId to set
-     */
-    public void setCodeId(String codeId) {
-	this.codeId = codeId;
-    }
-
-    /**
-     * code attribute를 리턴한다.
-     * 
-     * @return the code
-     */
-    public String getCode() {
-	return code;
-    }
-
-    /**
-     * code attribute 값을 설정한다.
-     * 
-     * @param code
-     *            the code to set
-     */
-    public void setCode(String code) {
-	this.code = code;
-    }
-
-    /**
-     * codeNm attribute를 리턴한다.
-     * 
-     * @return the codeNm
-     */
-    public String getCodeNm() {
-	return codeNm;
-    }
-
-    /**
-     * codeNm attribute 값을 설정한다.
-     * 
-     * @param codeNm
-     *            the codeNm to set
-     */
-    public void setCodeNm(String codeNm) {
-	this.codeNm = codeNm;
-    }
-
-    /**
-     * codeDc attribute를 리턴한다.
-     * 
-     * @return the codeDc
-     */
-    public String getCodeDc() {
-	return codeDc;
-    }
-
-    /**
-     * codeDc attribute 값을 설정한다.
-     * 
-     * @param codeDc
-     *            the codeDc to set
-     */
-    public void setCodeDc(String codeDc) {
-	this.codeDc = codeDc;
-    }
-
-    /**
-     * tableNm attribute를 리턴한다.
-     * 
-     * @return the tableNm
-     */
-    public String getTableNm() {
-	return tableNm;
-    }
-
-    /**
-     * tableNm attribute 값을 설정한다.
-     * 
-     * @param tableNm
-     *            the tableNm to set
-     */
-    public void setTableNm(String tableNm) {
-	this.tableNm = tableNm;
-    }
-
-    /**
-     * haveDetailCondition attribute를 리턴한다.
-     * 
-     * @return the haveDetailCondition
-     */
-    public String getHaveDetailCondition() {
-	return haveDetailCondition;
-    }
-
-    /**
-     * haveDetailCondition attribute 값을 설정한다.
-     * 
-     * @param haveDetailCondition
-     *            the haveDetailCondition to set
-     */
-    public void setHaveDetailCondition(String haveDetailCondition) {
-	this.haveDetailCondition = haveDetailCondition;
-    }
-
-    /**
-     * detailCondition attribute를 리턴한다.
-     * 
-     * @return the detailCondition
-     */
-    public String getDetailCondition() {
-	return detailCondition;
-    }
-
-    /**
-     * detailCondition attribute 값을 설정한다.
-     * 
-     * @param detailCondition
-     *            the detailCondition to set
-     */
-    public void setDetailCondition(String detailCondition) {
-	this.detailCondition = detailCondition;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cmm/ComDefaultVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultVO.java
@@ -2,6 +2,8 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -19,6 +21,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *  @see
  *
  */
+@Getter
+@Setter
 public class ComDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -6062858939907510631L;
@@ -56,113 +60,9 @@ public class ComDefaultVO implements Serializable {
 	/** 검색KeywordTo */
     private String searchKeywordTo = "";
 
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	public String getSearchCondition() {
-        return searchCondition;
-    }
-
-    public void setSearchCondition(String searchCondition) {
-        this.searchCondition = searchCondition;
-    }
-
-    public String getSearchKeyword() {
-        return searchKeyword;
-    }
-
-    public void setSearchKeyword(String searchKeyword) {
-        this.searchKeyword = searchKeyword;
-    }
-
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
     @Override
 	public String toString() {
         return ToStringBuilder.reflectionToString(this);
     }
 
-
-    /**
-	 * searchKeywordFrom attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordFrom() {
-		return searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordFrom attribute 값을 설정한다.
-	 * @param searchKeywordFrom String
-	 */
-	public void setSearchKeywordFrom(String searchKeywordFrom) {
-		this.searchKeywordFrom = searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordTo attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordTo() {
-		return searchKeywordTo;
-	}
-
-	/**
-	 * searchKeywordTo attribute 값을 설정한다.
-	 * @param searchKeywordTo String
-	 */
-	public void setSearchKeywordTo(String searchKeywordTo) {
-		this.searchKeywordTo = searchKeywordTo;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/LoginVO.java
+++ b/src/main/java/egovframework/com/cmm/LoginVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : LoginVO.java
  * @Description : Login VO class
@@ -15,15 +18,17 @@ import java.io.Serializable;
  *  @since 2009.03.03
  *  @version 1.0
  *  @see
- *  
+ *
  */
+@Getter
+@Setter
 public class LoginVO implements Serializable{
-	
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -8274004534207618049L;
-	
+
 	/** 아이디 */
 	private String id;
 	/** 이름 */
@@ -52,199 +57,5 @@ public class LoginVO implements Serializable{
 	private String ip;
 	/** GPKI인증 DN */
 	private String dn;
-	/**
-	 * id attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getId() {
-		return id;
-	}
-	/**
-	 * id attribute 값을 설정한다.
-	 * @param id String
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-	/**
-	 * name attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getName() {
-		return name;
-	}
-	/**
-	 * name attribute 값을 설정한다.
-	 * @param name String
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-	/**
-	 * ihidNum attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIhidNum() {
-		return ihidNum;
-	}
-	/**
-	 * ihidNum attribute 값을 설정한다.
-	 * @param ihidNum String
-	 */
-	public void setIhidNum(String ihidNum) {
-		this.ihidNum = ihidNum;
-	}
-	/**
-	 * email attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmail() {
-		return email;
-	}
-	/**
-	 * email attribute 값을 설정한다.
-	 * @param email String
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
-	/**
-	 * password attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	/**
-	 * passwordHint attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-	/**
-	 * passwordCnsr attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
-	/**
-	 * userSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserSe() {
-		return userSe;
-	}
-	/**
-	 * userSe attribute 값을 설정한다.
-	 * @param userSe String
-	 */
-	public void setUserSe(String userSe) {
-		this.userSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	/**
-	 * url attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUrl() {
-		return url;
-	}
-	/**
-	 * url attribute 값을 설정한다.
-	 * @param url String
-	 */
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	/**
-	 * ip attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIp() {
-		return ip;
-	}
-	/**
-	 * ip attribute 값을 설정한다.
-	 * @param ip String
-	 */
-	public void setIp(String ip) {
-		this.ip = ip;
-	}
-	/**
-	 * dn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDn() {
-		return dn;
-	}
-	/**
-	 * dn attribute 값을 설정한다.
-	 * @param dn String
-	 */
-	public void setDn(String dn) {
-		this.dn = dn;
-	}
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-	
+
 }

--- a/src/main/java/egovframework/com/cmm/service/FileVO.java
+++ b/src/main/java/egovframework/com/cmm/service/FileVO.java
@@ -2,6 +2,8 @@ package egovframework.com.cmm.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -19,6 +21,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @see
  *
  */
+@Getter
+@Setter
 public class FileVO implements Serializable {
 
     /**
@@ -28,210 +32,39 @@ public class FileVO implements Serializable {
 	/**
      * 첨부파일 아이디
      */
-    public String atchFileId = "";
+    private String atchFileId = "";
     /**
      * 생성일자
      */
-    public String creatDt = "";
+    private String creatDt = "";
     /**
      * 파일내용
      */
-    public String fileCn = "";
+    private String fileCn = "";
     /**
      * 파일확장자
      */
-    public String fileExtsn = "";
+    private String fileExtsn = "";
     /**
      * 파일크기
      */
-    public String fileMg = "";
+    private String fileMg = "";
     /**
      * 파일연번
      */
-    public String fileSn = "";
+    private String fileSn = "";
     /**
      * 파일저장경로
      */
-    public String fileStreCours = "";
+    private String fileStreCours = "";
     /**
      * 원파일명
      */
-    public String orignlFileNm = "";
+    private String orignlFileNm = "";
     /**
      * 저장파일명
      */
-    public String streFileNm = "";
-
-    /**
-     * atchFileId attribute를 리턴한다.
-     *
-     * @return the atchFileId
-     */
-    public String getAtchFileId() {
-	return atchFileId;
-    }
-
-    /**
-     * atchFileId attribute 값을 설정한다.
-     *
-     * @param atchFileId
-     *            the atchFileId to set
-     */
-    public void setAtchFileId(String atchFileId) {
-	this.atchFileId = atchFileId;
-    }
-
-    /**
-     * creatDt attribute를 리턴한다.
-     *
-     * @return the creatDt
-     */
-    public String getCreatDt() {
-	return creatDt;
-    }
-
-    /**
-     * creatDt attribute 값을 설정한다.
-     *
-     * @param creatDt
-     *            the creatDt to set
-     */
-    public void setCreatDt(String creatDt) {
-	this.creatDt = creatDt;
-    }
-
-    /**
-     * fileCn attribute를 리턴한다.
-     *
-     * @return the fileCn
-     */
-    public String getFileCn() {
-	return fileCn;
-    }
-
-    /**
-     * fileCn attribute 값을 설정한다.
-     *
-     * @param fileCn
-     *            the fileCn to set
-     */
-    public void setFileCn(String fileCn) {
-	this.fileCn = fileCn;
-    }
-
-    /**
-     * fileExtsn attribute를 리턴한다.
-     *
-     * @return the fileExtsn
-     */
-    public String getFileExtsn() {
-	return fileExtsn;
-    }
-
-    /**
-     * fileExtsn attribute 값을 설정한다.
-     *
-     * @param fileExtsn
-     *            the fileExtsn to set
-     */
-    public void setFileExtsn(String fileExtsn) {
-	this.fileExtsn = fileExtsn;
-    }
-
-    /**
-     * fileMg attribute를 리턴한다.
-     *
-     * @return the fileMg
-     */
-    public String getFileMg() {
-	return fileMg;
-    }
-
-    /**
-     * fileMg attribute 값을 설정한다.
-     *
-     * @param fileMg
-     *            the fileMg to set
-     */
-    public void setFileMg(String fileMg) {
-	this.fileMg = fileMg;
-    }
-
-    /**
-     * fileSn attribute를 리턴한다.
-     *
-     * @return the fileSn
-     */
-    public String getFileSn() {
-	return fileSn;
-    }
-
-    /**
-     * fileSn attribute 값을 설정한다.
-     *
-     * @param fileSn
-     *            the fileSn to set
-     */
-    public void setFileSn(String fileSn) {
-	this.fileSn = fileSn;
-    }
-
-    /**
-     * fileStreCours attribute를 리턴한다.
-     *
-     * @return the fileStreCours
-     */
-    public String getFileStreCours() {
-	return fileStreCours;
-    }
-
-    /**
-     * fileStreCours attribute 값을 설정한다.
-     *
-     * @param fileStreCours
-     *            the fileStreCours to set
-     */
-    public void setFileStreCours(String fileStreCours) {
-	this.fileStreCours = fileStreCours;
-    }
-
-    /**
-     * orignlFileNm attribute를 리턴한다.
-     *
-     * @return the orignlFileNm
-     */
-    public String getOrignlFileNm() {
-	return orignlFileNm;
-    }
-
-    /**
-     * orignlFileNm attribute 값을 설정한다.
-     *
-     * @param orignlFileNm
-     *            the orignlFileNm to set
-     */
-    public void setOrignlFileNm(String orignlFileNm) {
-	this.orignlFileNm = orignlFileNm;
-    }
-
-    /**
-     * streFileNm attribute를 리턴한다.
-     *
-     * @return the streFileNm
-     */
-    public String getStreFileNm() {
-	return streFileNm;
-    }
-
-    /**
-     * streFileNm attribute 값을 설정한다.
-     *
-     * @param streFileNm
-     *            the streFileNm to set
-     */
-    public void setStreFileNm(String streFileNm) {
-	this.streFileNm = streFileNm;
-    }
+    private String streFileNm = "";
 
     /**
      * toString 메소드를 대치한다.


### PR DESCRIPTION
## 변경 사유

LoginVO, ComDefaultVO, ComDefaultCodeVO, FileVO 4개 핵심 VO 클래스에 필드당 getter/setter가 수작업으로 반복 선언되어 있어 코드 가독성이 낮고 유지보수 비용이 높습니다. pom.xml에 Lombok이 이미 `provided` scope로 등록되어 있어 즉시 활용 가능합니다.

## 변경 내용

| 클래스 | 제거된 접근자 수 |
|---|---|
| `LoginVO` | 28개 (14필드 × getter+setter) |
| `ComDefaultVO` | 20개 (10필드 × getter+setter) |
| `ComDefaultCodeVO` | 14개 (7필드 × getter+setter) |
| `FileVO` | 18개 (9필드 × getter+setter) |
| **합계** | **80개** |

- 각 클래스에 `@Getter`, `@Setter` 클래스 레벨 어노테이션 추가
- `serialVersionUID` 보존
- `toString()` 기존 구현(`ToStringBuilder.reflectionToString`) 보존
- `FileVO` 필드 접근 제어자 `public` → `private` 정정 (기존에도 getter/setter를 통해 접근하는 구조였으므로 동작 변화 없음)
- `SessionVO`는 setter 파라미터명이 필드명과 달라 Lombok 자동 생성 시 동작이 달라지므로 이번 변경에서 제외

## 영향 범위

- 호출부(Controller, Service), JSP EL(`${loginVO.id}` 등), MyBatis 매퍼 결과 매핑 모두 getter/setter 네이밍 규칙 유지로 영향 없음
- `provided` scope이므로 배포 산출물 크기 변화 없음

## PR #37 관계

외부 PR #37(Kotlin/Gradle 마이그레이션)과 변경 파일이 겹치지 않습니다. 본 PR은 Java 소스 파일만 수정합니다.

## 체크리스트

- [x] 단일 주제만 다룸 (Lombok 적용 외 다른 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 (해당 없음 — 5.0.x 단일 브랜치)
- [x] 의존성 추가가 필요한 경우 선행 PR 링크 명시 (pom.xml에 이미 등록됨)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인