### PR TITLE
[test] Selenium 테스트 정비 또는 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 		<commons-beanutils.version>1.11.0</commons-beanutils.version>
 		<protobuf.java.version>3.25.5</protobuf.java.version>
 		<parsson.version>1.1.7</parsson.version>
+		<skipTests>true</skipTests>
 	</properties>
 
 	<dependencies>
@@ -263,6 +264,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.42</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -282,7 +290,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>${skipTests}</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,53 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovNumberUtil 단위 테스트
+ * 
+ * @since 2026-05-21
+ */
+class EgovNumberUtilTest {
+
+	@Test
+	void testGetRandomNum() {
+		int start = 10;
+		int end = 20;
+		for (int i = 0; i < 100; i++) {
+			int rand = EgovNumberUtil.getRandomNum(start, end);
+			assertTrue(rand >= start && rand <= end);
+		}
+	}
+
+	@Test
+	void testGetNumSearchCheck() {
+		assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 7));
+		assertFalse(EgovNumberUtil.getNumSearchCheck(12345678, 9));
+	}
+
+	@Test
+	void testGetNumToStrCnvr() {
+		assertEquals("20260521", EgovNumberUtil.getNumToStrCnvr(20260521));
+	}
+
+	@Test
+	void testGetNumberValidCheck() {
+		assertTrue(EgovNumberUtil.getNumberValidCheck("12345"));
+		assertFalse(EgovNumberUtil.getNumberValidCheck("123a5"));
+	}
+
+	@Test
+	void testGetNumberCnvr() {
+		assertEquals(99945678, EgovNumberUtil.getNumberCnvr(12345678, 123, 999));
+	}
+
+	@Test
+	void testCheckRlnoInteger() {
+		assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-5.5));
+		assertEquals(1, EgovNumberUtil.checkRlnoInteger(5.5));
+	}
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
@@ -1,0 +1,56 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovStringUtil 단위 테스트
+ * 
+ * @since 2026-05-21
+ */
+class EgovStringUtilTest {
+
+	@Test
+	void testIsEmpty() {
+		assertTrue(EgovStringUtil.isEmpty(null));
+		assertTrue(EgovStringUtil.isEmpty(""));
+		assertFalse(EgovStringUtil.isEmpty(" "));
+		assertFalse(EgovStringUtil.isEmpty("abc"));
+	}
+
+	@Test
+	void testRemove() {
+		assertNull(EgovStringUtil.remove(null, 'u'));
+		assertEquals("", EgovStringUtil.remove("", 'u'));
+		assertEquals("qeed", EgovStringUtil.remove("queued", 'u'));
+		assertEquals("queued", EgovStringUtil.remove("queued", 'z'));
+	}
+
+	@Test
+	void testRemoveCommaChar() {
+		assertNull(EgovStringUtil.removeCommaChar(null));
+		assertEquals("asdfgqweqe", EgovStringUtil.removeCommaChar("asdfg,qweqe"));
+	}
+
+	@Test
+	void testRemoveMinusChar() {
+		assertNull(EgovStringUtil.removeMinusChar(null));
+		assertEquals("asdfgqweqe", EgovStringUtil.removeMinusChar("a-sdfg-qweqe"));
+	}
+
+	@Test
+	void testCutString() {
+		assertEquals("abc...", EgovStringUtil.cutString("abcdefg", "...", 3));
+		assertEquals("abcdefg", EgovStringUtil.cutString("abcdefg", "...", 10));
+		assertNull(EgovStringUtil.cutString(null, "...", 3));
+	}
+
+	@Test
+	void testReplace() {
+		assertEquals("a_c", EgovStringUtil.replace("abc", "b", "_"));
+	}
+}


### PR DESCRIPTION
유틸리티 클래스(EgovNumberUtil, EgovStringUtil)에 대한 단위 테스트를 추가하고 테스트 빌드 환경을 개선했습니다.

1. EgovNumberUtilTest, EgovStringUtilTest 추가
- 각 유틸리티의 주요 정적 메서드에 대한 단위 테스트 코드를 추가하여 검증을 강화했습니다.

2. pom.xml 빌드 설정 보완
- Java 17 및 Lombok 환경에서 테스트 컴파일 오류가 발생하는 부분을 해결하기 위해 maven-compiler-plugin의 annotationProcessorPaths에 lombok 의존성을 구성하였습니다.
- 로컬 또는 CI 환경에서 단위 테스트를 선택적으로 수행하거나 비활성화할 수 있도록 skipTests 속성을 설정할 수 있게 조정하였습니다.