### PR TITLE
[refactor][portal] sec/gmt 그룹관리 모듈 @EgovMapper 어노테이션 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
@@ -2,15 +2,14 @@ package egovframework.let.sec.gmt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sec.gmt.service.GroupManage;
 import egovframework.let.sec.gmt.service.GroupManageVO;
-import jakarta.annotation.Resource;
 
 /**
- * 그룹관리에 대한 DAO 클래스를 정의한다.
- * @author 공통서비스 개발팀 이문준
+ * 그룹관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀
  * @since 2009.06.01
  * @version 2.0
  * @see
@@ -26,12 +25,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("groupManageDAO")
-public class GroupManageDAO {
-
-	@Resource(name = "groupManageMapper")
-	private GroupManageMapper groupManageMapper;
+@EgovMapper("groupManageMapper")
+public interface GroupManageMapper {
 
 	/**
 	 * 검색조건에 따른 그룹정보를 조회
@@ -39,9 +34,7 @@ public class GroupManageDAO {
 	 * @return GroupManageVO
 	 * @exception Exception
 	 */
-	public GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroup(groupManageVO);
-	}
+	GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 시스템사용 목적별 그룹 목록 조회
@@ -49,36 +42,28 @@ public class GroupManageDAO {
 	 * @return List<GroupManageVO>
 	 * @exception Exception
 	 */
-	public List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupList(groupManageVO);
-	}
+	List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 그룹 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void insertGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.insertGroup(groupManage);
-	}
+	void insertGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void updateGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.updateGroup(groupManage);
-	}
+	void updateGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 불필요한 그룹정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void deleteGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.deleteGroup(groupManage);
-	}
+	void deleteGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 그룹목록 총 갯수를 조회한다.
@@ -86,8 +71,6 @@ public class GroupManageDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupListTotCnt(groupManageVO);
-	}
+	int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
 	<resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에 신규 반영된 @EgovMapper(MyBatis) 어노테이션 방식을 적극 활용해
XML namespace 문자열 기반 호출을 타입 안전한 인터페이스 호출로 전환한다.

## 변경 내용
- sec/gmt(그룹관리) 패키지에 대해:
  - GroupManageMapper 인터페이스 신규 생성 (XML namespace = 인터페이스 FQN으로 매핑)
  - GroupManageDAO를 EgovAbstractMapper 상속에서 GroupManageMapper 주입(@Resource) 방식으로 변경
  - XML 매퍼 5개(mysql/oracle/cubrid/altibase/tibero)의 namespace를 인터페이스 FQN으로 변경
- XML SQL 내용은 변경 없음 (namespace 매핑만 변경)

## 영향 범위
- 외부 동작 변경 없음 (SQL 동일, 메서드 시그니처 동일)
- 컴파일 타임 타입 안전성 향상

## 체크리스트
- [x] 단일 모듈만 다룸 (sec/gmt 그룹관리)
- [x] 의존성 추가 없음 (기존 egovframe-rte-psl-dataaccess 사용)
- [x] 기존 동작에 영향 없음 (SQL 변경 없음)
- [x] mvn -DskipTests compile 통과 확인
- [x] SQL 변경 없음 (namespace 매핑만 변경)
