### PR TITLE
[refactor][portal] sec/rgm 권한그룹 XML 매퍼 @EgovMapper 인터페이스 방식 전환

### DIFF
--- a/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
@@ -2,14 +2,13 @@ package egovframework.let.sec.rgm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sec.rgm.service.AuthorGroup;
 import egovframework.let.sec.rgm.service.AuthorGroupVO;
-import jakarta.annotation.Resource;
 
 /**
- * 권한그룹에 대한 DAO 클래스를 정의한다.
+ * 권한그룹에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 2.0
@@ -26,12 +25,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("authorGroupDAO")
-public class AuthorGroupDAO {
-
-	@Resource(name = "authorGroupMapper")
-	private AuthorGroupMapper authorGroupMapper;
+@EgovMapper("authorGroupMapper")
+public interface AuthorGroupMapper {
 
 	/**
 	 * 그룹별 할당된 권한 목록 조회
@@ -39,36 +34,28 @@ public class AuthorGroupDAO {
 	 * @return List<AuthorGroupVO>
 	 * @exception Exception
 	 */
-	public List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupList(authorGroupVO);
-	}
+	List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception;
 
 	/**
 	 * 그룹에 권한정보를 할당하여 데이터베이스에 등록
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void insertAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.insertAuthorGroup(authorGroup);
-	}
+	void insertAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹권한정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void updateAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.updateAuthorGroup(authorGroup);
-	}
+	void updateAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹별 할당된 시스템 메뉴 접근권한을 삭제
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.deleteAuthorGroup(authorGroup);
-	}
+	void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹권한목록 총 갯수를 조회한다.
@@ -76,8 +63,6 @@ public class AuthorGroupDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupListTotCnt(authorGroupVO);
-	}
+	int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에 신규 반영된 `@EgovMapper` 어노테이션 방식을 sec/rgm(권한그룹) 모듈에 적용하여 XML namespace 문자열 기반 호출을 타입 안전한 인터페이스 호출로 전환한다.

## 변경 내용

- `AuthorGroupMapper` 인터페이스 신설 (`@EgovMapper("authorGroupMapper")` 어노테이션 적용)
- `AuthorGroupDAO`: `EgovAbstractMapper` 상속 제거, `@Resource(name = "authorGroupMapper")` 주입 방식으로 전환
- XML 매퍼 5종(mysql/oracle/cubrid/altibase/tibero)의 namespace를 인터페이스 FQN(`egovframework.let.sec.rgm.service.impl.AuthorGroupMapper`)으로 변경

## 영향 범위

- SQL 내용 변경 없음 (namespace 매핑만 변경)
- 외부 API(서비스 인터페이스, 컨트롤러) 변경 없음
- 의존성 추가 없음 (기존 `egovframe-rte-psl-dataaccess` 사용)

## 체크리스트

- [x] 단일 모듈만 다룸 (sec/rgm 권한그룹)
- [x] 의존성 추가 없음
- [x] 기존 동작에 영향 없음 (SQL 변경 없음)
- [x] mvn -DskipTests compile 통과 확인
- [x] SQL 변경 없음 (namespace 매핑만 변경)
