### PR TITLE
[refactor][portal] uss/sam/ipm 개인정보보호정책 XML 매퍼 @EgovMapper 인터페이스 방식 전환

### DIFF
--- a/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
+++ b/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
@@ -2,14 +2,13 @@ package egovframework.let.uss.sam.ipm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy;
-import jakarta.annotation.Resource;
 
 /**
- * 개인정보보호정책를 처리하는 Dao Class 구현
+ * 개인정보보호정책를 처리하는 Mapper 인터페이스
  * @author 공통서비스 장동한
  * @since 2009.07.03
  * @version 2.0
@@ -24,11 +23,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("onlineIndvdlInfoPolicyDao")
-public class IndvdlInfoPolicyDao {
-
-    @Resource(name = "onlineIndvdlInfoPolicyMapper")
-    private IndvdlInfoPolicyMapper indvdlInfoPolicyMapper;
+@EgovMapper("onlineIndvdlInfoPolicyMapper")
+public interface IndvdlInfoPolicyMapper {
 
     /**
      * 개인정보보호정책를(을) 목록을 한다.
@@ -36,9 +32,7 @@ public class IndvdlInfoPolicyDao {
      * @return List
      * @throws Exception
      */
-    public List<?> selectIndvdlInfoPolicyList(ComDefaultVO searchVO) throws Exception {
-        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicy(searchVO);
-    }
+    List<?> selectIndvdlInfoPolicy(ComDefaultVO searchVO) throws Exception;
 
     /**
      * 개인정보보호정책를(을) 목록 전체 건수를(을) 조회한다.
@@ -46,9 +40,7 @@ public class IndvdlInfoPolicyDao {
      * @return int
      * @throws Exception
      */
-    public int selectIndvdlInfoPolicyListCnt(ComDefaultVO searchVO) throws Exception {
-        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyCnt(searchVO);
-    }
+    int selectIndvdlInfoPolicyCnt(ComDefaultVO searchVO) throws Exception;
 
     /**
      * 개인정보보호정책를(을) 상세조회 한다.
@@ -56,35 +48,27 @@ public class IndvdlInfoPolicyDao {
      * @return IndvdlInfoPolicy
      * @throws Exception
      */
-    public IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyDetail(indvdlInfoPolicy);
-    }
+    IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
 
     /**
      * 개인정보보호정책를(을) 등록한다.
      * @param indvdlInfoPolicy  개인정보보호정책 정보가 담김 VO
      * @throws Exception
      */
-    public void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        indvdlInfoPolicyMapper.insertIndvdlInfoPolicy(indvdlInfoPolicy);
-    }
+    void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
 
     /**
      * 개인정보보호정책를(을) 수정한다.
      * @param indvdlInfoPolicy  개인정보보호정책 정보가 담김 VO
      * @throws Exception
      */
-    public void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        indvdlInfoPolicyMapper.updateIndvdlInfoPolicy(indvdlInfoPolicy);
-    }
+    void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
 
     /**
      * 개인정보보호정책를(을) 삭제한다.
      * @param indvdlInfoPolicy  개인정보보호정책 정보가 담김 VO
      * @throws Exception
      */
-    public void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        indvdlInfoPolicyMapper.deleteIndvdlInfoPolicy(indvdlInfoPolicy);
-    }
+    void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에 신규 반영된 @EgovMapper(MyBatis) 어노테이션 방식을 활용해
XML namespace 문자열 기반 호출을 타입 안전한 인터페이스 호출로 전환한다.
PR #49(sec/gmt), #51(sec/rgm), #52(sec/rmt)와 동일한 패턴.

## 변경 내용
- uss/sam/ipm(개인정보보호정책) 패키지에 대해:
  - IndvdlInfoPolicyMapper 인터페이스 신규 생성 (XML namespace = 인터페이스 FQN으로 매핑)
  - IndvdlInfoPolicyDao를 EgovAbstractMapper 상속에서 IndvdlInfoPolicyMapper 주입(@Resource) 방식으로 변경
  - XML 매퍼 5개(mysql/oracle/cubrid/altibase/tibero)의 namespace를 인터페이스 FQN으로 변경
- XML SQL 내용은 변경 없음 (namespace 매핑만 변경)

## 영향 범위
- 외부 동작 변경 없음 (SQL 동일, 메서드 시그니처 동일)
- 컴파일 타임 타입 안전성 향상

## 체크리스트
- [x] 단일 모듈만 다룸 (uss/sam/ipm 개인정보보호정책)
- [x] 의존성 추가 없음 (기존 egovframe-rte-psl-dataaccess 사용)
- [x] 기존 동작에 영향 없음 (SQL 변경 없음)
- [x] mvn -DskipTests compile 통과 확인
- [x] SQL 변경 없음 (namespace 매핑만 변경)
- [x] PR #49, #51, #52와 다른 모듈
