### PR TITLE
[refactor][portal] 설문(olp) 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/uss/olp/qim/service/QustnrItemManageVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qim/service/QustnrItemManageVO.java
@@ -1,9 +1,14 @@
 package egovframework.let.uss.olp.qim.service;
 
 import java.io.Serializable;
+
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 설문항목관리 VO Class 구현
  * @author 공통서비스 장동한
@@ -13,7 +18,7 @@ import jakarta.validation.constraints.Pattern;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
@@ -21,8 +26,10 @@ import jakarta.validation.constraints.Pattern;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrItemManageVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -30,236 +37,43 @@ public class QustnrItemManageVO implements Serializable {
 
 	/** 설문문항 아이디 */
 	private String qestnrQesitmId = "";
-	
+
 	/** 설문지 아이디 */
 	private String qestnrId = "";
-	
+
 	/** 항목순번 */
 	@EgovNullCheck
 	@Size(max=5)
 	@Pattern(regexp = "^[0-9]*$", message = "{validation.integer.check}")
 	private String iemSn = "";
-	
+
 	/** 항목내용 */
 	private String qustnrIemId = "";
-	
+
 	/** 설문항목아이디 */
 	@EgovNullCheck
 	@Size(max=1000)
 	private String iemCn = "";
-	
+
 	/** 키타답변여부 */
 	private String etcAnswerAt = "";
-	
+
 	/** 설문항목(을)를 아이디 */
 	private String qestnrTmplatId = "";
-	
+
 	/** 최초등록시점  */
 	private String frstRegisterPnttm = "";
-	
+
 	/** 최초등록아이디 */
 	private String frstRegisterId = "";
-	
+
 	/** 최종수정일 */
 	private String lastUpdusrPnttm = "";
-	
+
 	/** 최종수정자 아이디 */
 	private String lastUpdusrId = "";
-	
+
 	/** 컨트롤 명령어 */
 	private String cmd = "";
 
-	/**
-	 * qestnrQesitmId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrQesitmId() {
-		return qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrQesitmId attribute 값을 설정한다.
-	 * @return qestnrQesitmId String
-	 */
-	public void setQestnrQesitmId(String qestnrQesitmId) {
-		this.qestnrQesitmId = qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrId() {
-		return qestnrId;
-	}
-
-	/**
-	 * qestnrId attribute 값을 설정한다.
-	 * @return qestnrId String
-	 */
-	public void setQestnrId(String qestnrId) {
-		this.qestnrId = qestnrId;
-	}
-
-	/**
-	 * iemSn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getIemSn() {
-		return iemSn;
-	}
-
-	/**
-	 * iemSn attribute 값을 설정한다.
-	 * @return iemSn String
-	 */
-	public void setIemSn(String iemSn) {
-		this.iemSn = iemSn;
-	}
-
-	/**
-	 * qustnrIemId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQustnrIemId() {
-		return qustnrIemId;
-	}
-
-	/**
-	 * qustnrIemId attribute 값을 설정한다.
-	 * @return qustnrIemId String
-	 */
-	public void setQustnrIemId(String qustnrIemId) {
-		this.qustnrIemId = qustnrIemId;
-	}
-
-	/**
-	 * iemCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getIemCn() {
-		return iemCn;
-	}
-
-	/**
-	 * iemCn attribute 값을 설정한다.
-	 * @return iemCn String
-	 */
-	public void setIemCn(String iemCn) {
-		this.iemCn = iemCn;
-	}
-
-	/**
-	 * etcAnswerAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEtcAnswerAt() {
-		return etcAnswerAt;
-	}
-
-	/**
-	 * etcAnswerAt attribute 값을 설정한다.
-	 * @return etcAnswerAt String
-	 */
-	public void setEtcAnswerAt(String etcAnswerAt) {
-		this.etcAnswerAt = etcAnswerAt;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * cmd attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getCmd() {
-		return cmd;
-	}
-
-	/**
-	 * cmd attribute 값을 설정한다.
-	 * @return cmd String
-	 */
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-	
-	
 }

--- a/src/main/java/egovframework/let/uss/olp/qmc/service/QustnrManageVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qmc/service/QustnrManageVO.java
@@ -1,8 +1,13 @@
 package egovframework.let.uss.olp.qmc.service;
 
 import java.io.Serializable;
+
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 설문관리 VO Class 구현
  * @author 공통서비스 장동한
@@ -12,7 +17,7 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
@@ -20,269 +25,61 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrManageVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1L;
 
 	/** 설문지ID */
-	private String qestnrId =  "";
-	
+	private String qestnrId = "";
+
 	/**  설문제목 */
 	@EgovNullCheck
 	@Size(max=250)
-	private String qestnrSj =  "";
-	
+	private String qestnrSj = "";
+
 	/**  설문목적 */
 	@EgovNullCheck
 	@Size(max=1000)
-	private String qestnrPurps =  "";
-	
+	private String qestnrPurps = "";
+
 	/**  설문작성안내내용 */
 	@EgovNullCheck
 	@Size(max=2000)
-	private String qestnrWritngGuidanceCn =  "";
-	
+	private String qestnrWritngGuidanceCn = "";
+
 	/**  설문시작일자 */
 	@EgovNullCheck
-	private String qestnrBeginDe =  "";
-	
+	private String qestnrBeginDe = "";
+
 	/**  설문종료일자 */
 	@EgovNullCheck
-	private String qestnrEndDe =  "";
-	
+	private String qestnrEndDe = "";
+
 	/**  설문대상 */
 	@EgovNullCheck
-	private String qestnrTrget =  "";
-	
+	private String qestnrTrget = "";
+
 	/**  설문시작일자 */
-	private String qestnrTmplatId =  "";
+	private String qestnrTmplatId = "";
 
 	/**  설문템플릿유형 */
-	private String qestnrTmplatTy =  "";
-	
+	private String qestnrTmplatTy = "";
+
 	/**  최초등록시점 */
-	private String frstRegisterPnttm =  "";
-	
+	private String frstRegisterPnttm = "";
+
 	/**  최초등록자아이디 */
-	private String frstRegisterId =  "";
-	
+	private String frstRegisterId = "";
+
 	/**  최종수정시점 */
-	private String lastUpdusrPnttm =  "";
-	
+	private String lastUpdusrPnttm = "";
+
 	/**  최종수정자아이디 */
-	private String lastUpdusrId =  "";
+	private String lastUpdusrId = "";
 
-	/**
-	 * qestnrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrId() {
-		return qestnrId;
-	}
-
-	/**
-	 * qestnrId attribute 값을 설정한다.
-	 * @return qestnrId String
-	 */
-	public void setQestnrId(String qestnrId) {
-		this.qestnrId = qestnrId;
-	}
-
-	/**
-	 * qestnrSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrSj() {
-		return qestnrSj;
-	}
-
-	/**
-	 * qestnrSj attribute 값을 설정한다.
-	 * @return qestnrSj String
-	 */
-	public void setQestnrSj(String qestnrSj) {
-		this.qestnrSj = qestnrSj;
-	}
-
-	/**
-	 * qestnrPurps attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrPurps() {
-		return qestnrPurps;
-	}
-
-	/**
-	 * qestnrPurps attribute 값을 설정한다.
-	 * @return qestnrPurps String
-	 */
-	public void setQestnrPurps(String qestnrPurps) {
-		this.qestnrPurps = qestnrPurps;
-	}
-
-	/**
-	 * qestnrWritngGuidanceCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrWritngGuidanceCn() {
-		return qestnrWritngGuidanceCn;
-	}
-
-	/**
-	 * qestnrWritngGuidanceCn attribute 값을 설정한다.
-	 * @return qestnrWritngGuidanceCn String
-	 */
-	public void setQestnrWritngGuidanceCn(String qestnrWritngGuidanceCn) {
-		this.qestnrWritngGuidanceCn = qestnrWritngGuidanceCn;
-	}
-
-	/**
-	 * qestnrBeginDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrBeginDe() {
-		return qestnrBeginDe;
-	}
-
-	/**
-	 * qestnrBeginDe attribute 값을 설정한다.
-	 * @return qestnrBeginDe String
-	 */
-	public void setQestnrBeginDe(String qestnrBeginDe) {
-		this.qestnrBeginDe = qestnrBeginDe;
-	}
-
-	/**
-	 * qestnrEndDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrEndDe() {
-		return qestnrEndDe;
-	}
-
-	/**
-	 * qestnrEndDe attribute 값을 설정한다.
-	 * @return qestnrEndDe String
-	 */
-	public void setQestnrEndDe(String qestnrEndDe) {
-		this.qestnrEndDe = qestnrEndDe;
-	}
-
-	/**
-	 * qestnrTrget attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTrget() {
-		return qestnrTrget;
-	}
-
-	/**
-	 * qestnrTrget attribute 값을 설정한다.
-	 * @return qestnrTrget String
-	 */
-	public void setQestnrTrget(String qestnrTrget) {
-		this.qestnrTrget = qestnrTrget;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatTy attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatTy() {
-		return qestnrTmplatTy;
-	}
-
-	/**
-	 * qestnrTmplatTy attribute 값을 설정한다.
-	 * @return qestnrTmplatTy String
-	 */
-	public void setQestnrTmplatTy(String qestnrTmplatTy) {
-		this.qestnrTmplatTy = qestnrTmplatTy;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-	
-	
-	
 }

--- a/src/main/java/egovframework/let/uss/olp/qqm/service/QustnrQestnManageVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qqm/service/QustnrQestnManageVO.java
@@ -6,8 +6,12 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 설문문항 VO Class 구현 
+ * 설문문항 VO Class 구현
  * @author 공통서비스 장동한
  * @since 2009.03.20
  * @version 1.0
@@ -15,15 +19,17 @@ import jakarta.validation.constraints.Pattern;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrQestnManageVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -31,256 +37,48 @@ public class QustnrQestnManageVO implements Serializable {
 
 	/** 설문제목 */
 	private String qestnrSj = "";
-	
+
 	/** 설문문항 ID */
 	private String qestnrQesitmId = "";
-	
+
 	/** 설문지 ID */
 	private String qestnrId = "";
-	
+
 	/** 질문순번 */
 	@EgovNullCheck
 	@Size(max=10)
 	@Pattern(regexp = "^[0-9]*$", message = "{validation.integer.check}")
 	private String qestnSn = "";
-	
+
 	/** 질문유형코드 */
 	@EgovNullCheck
 	private String qestnTyCode = "";
-	
+
 	/** 질문내용 */
 	@EgovNullCheck
 	@Size(max=2500)
 	private String qestnCn = "";
-	
+
 	/** 초대선택건수 */
 	private String mxmmChoiseCo = "";
-	
+
 	/** 템플릿 ID */
 	private String qestnrTmplatId = "";
-	
+
 	/** 최초등록자아이디 */
 	private String frstRegisterPnttm = "";
-	
+
 	/** 최초등록시점  */
 	private String frstRegisterId = "";
-	
+
 	/** 최종수정시점 */
 	private String lastUpdusrPnttm = "";
-	
+
 	/** 최종수정시점아이디  */
 	private String lastUpdusrId = "";
 
 	/** 검색모드설정  */
 	private String searchMode = "";
-
-	/**
-	 * qestnrSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrSj() {
-		return qestnrSj;
-	}
-
-	/**
-	 * qestnrSj attribute 값을 설정한다.
-	 * @return qestnrSj String
-	 */
-	public void setQestnrSj(String qestnrSj) {
-		this.qestnrSj = qestnrSj;
-	}
-
-	/**
-	 * qestnrQesitmId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrQesitmId() {
-		return qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrQesitmId attribute 값을 설정한다.
-	 * @return qestnrQesitmId String
-	 */
-	public void setQestnrQesitmId(String qestnrQesitmId) {
-		this.qestnrQesitmId = qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrId() {
-		return qestnrId;
-	}
-
-	/**
-	 * qestnrId attribute 값을 설정한다.
-	 * @return qestnrId String
-	 */
-	public void setQestnrId(String qestnrId) {
-		this.qestnrId = qestnrId;
-	}
-
-	/**
-	 * qestnSn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnSn() {
-		return qestnSn;
-	}
-
-	/**
-	 * qestnSn attribute 값을 설정한다.
-	 * @return qestnSn String
-	 */
-	public void setQestnSn(String qestnSn) {
-		this.qestnSn = qestnSn;
-	}
-
-	/**
-	 * qestnTyCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnTyCode() {
-		return qestnTyCode;
-	}
-
-	/**
-	 * qestnTyCode attribute 값을 설정한다.
-	 * @return qestnTyCode String
-	 */
-	public void setQestnTyCode(String qestnTyCode) {
-		this.qestnTyCode = qestnTyCode;
-	}
-
-	/**
-	 * qestnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnCn() {
-		return qestnCn;
-	}
-
-	/**
-	 * qestnCn attribute 값을 설정한다.
-	 * @return qestnCn String
-	 */
-	public void setQestnCn(String qestnCn) {
-		this.qestnCn = qestnCn;
-	}
-
-	/**
-	 * mxmmChoiseCo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getMxmmChoiseCo() {
-		return mxmmChoiseCo;
-	}
-
-	/**
-	 * mxmmChoiseCo attribute 값을 설정한다.
-	 * @return mxmmChoiseCo String
-	 */
-	public void setMxmmChoiseCo(String mxmmChoiseCo) {
-		this.mxmmChoiseCo = mxmmChoiseCo;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * searchMode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchMode() {
-		return searchMode;
-	}
-
-	/**
-	 * searchMode attribute 값을 설정한다.
-	 * @return searchMode String
-	 */
-	public void setSearchMode(String searchMode) {
-		this.searchMode = searchMode;
-	}
 
 	/**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/let/uss/olp/qri/service/QustnrRespondInfoVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qri/service/QustnrRespondInfoVO.java
@@ -5,8 +5,12 @@ import java.io.Serializable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 설문조사 VO Class 구현 
+ * 설문조사 VO Class 구현
  * @author 공통서비스 장동한
  * @since 2009.03.20
  * @version 1.0
@@ -14,7 +18,7 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
@@ -22,244 +26,54 @@ import jakarta.validation.constraints.Size;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrRespondInfoVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
 	private static final long serialVersionUID = 1L;
 
 	/** 설문응답ID */
-	private String qestnrQesrspnsId = ""; 
-	
+	private String qestnrQesrspnsId = "";
+
 	/** 설문문항ID */
 	private String qestnrQesitmId = "";
-	
+
 	/** 설문ID */
 	private String qestnrId = "";
-	
+
 	/** 설문템플릿ID */
 	private String qestnrTmplatId = "";
-	
+
 	/** 설문항목ID */
 	private String qustnrIemId = "";
-	
+
 	/** 응답자답변내용 */
 	@Size(max=1000)
 	private String respondAnswerCn = "";
-	
+
 	/** 응답자명 */
 	@EgovNullCheck
 	@Size(max=50)
 	private String respondNm = "";
-	
+
 	/** 기타답변내용 */
 	@Size(max=1000)
 	private String etcAnswerCn = "";
-	
+
 	/** 최초등록시점 */
 	private String frstRegisterPnttm = "";
-	
+
 	/** 최등등록시점ID */
 	private String frstRegisterId = "";
-	
+
 	/** 최종수정시점 */
 	private String lastUpdusrPnttm = "";
-	
+
 	/** 최종수정시점ID */
 	private String lastUpdusrId = "";
-
-	/**
-	 * qestnrQesrspnsId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrQesrspnsId() {
-		return qestnrQesrspnsId;
-	}
-
-	/**
-	 * qestnrQesrspnsId attribute 값을 설정한다.
-	 * @return qestnrQesrspnsId String
-	 */
-	public void setQestnrQesrspnsId(String qestnrQesrspnsId) {
-		this.qestnrQesrspnsId = qestnrQesrspnsId;
-	}
-
-	/**
-	 * qestnrQesitmId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrQesitmId() {
-		return qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrQesitmId attribute 값을 설정한다.
-	 * @return qestnrQesitmId String
-	 */
-	public void setQestnrQesitmId(String qestnrQesitmId) {
-		this.qestnrQesitmId = qestnrQesitmId;
-	}
-
-	/**
-	 * qestnrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrId() {
-		return qestnrId;
-	}
-
-	/**
-	 * qestnrId attribute 값을 설정한다.
-	 * @return qestnrId String
-	 */
-	public void setQestnrId(String qestnrId) {
-		this.qestnrId = qestnrId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
-
-	/**
-	 * qustnrIemId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQustnrIemId() {
-		return qustnrIemId;
-	}
-
-	/**
-	 * qustnrIemId attribute 값을 설정한다.
-	 * @return qustnrIemId String
-	 */
-	public void setQustnrIemId(String qustnrIemId) {
-		this.qustnrIemId = qustnrIemId;
-	}
-
-	/**
-	 * respondAnswerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRespondAnswerCn() {
-		return respondAnswerCn;
-	}
-
-	/**
-	 * respondAnswerCn attribute 값을 설정한다.
-	 * @return respondAnswerCn String
-	 */
-	public void setRespondAnswerCn(String respondAnswerCn) {
-		this.respondAnswerCn = respondAnswerCn;
-	}
-
-	/**
-	 * respondNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRespondNm() {
-		return respondNm;
-	}
-
-	/**
-	 * respondNm attribute 값을 설정한다.
-	 * @return respondNm String
-	 */
-	public void setRespondNm(String respondNm) {
-		this.respondNm = respondNm;
-	}
-
-	/**
-	 * etcAnswerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEtcAnswerCn() {
-		return etcAnswerCn;
-	}
-
-	/**
-	 * etcAnswerCn attribute 값을 설정한다.
-	 * @return etcAnswerCn String
-	 */
-	public void setEtcAnswerCn(String etcAnswerCn) {
-		this.etcAnswerCn = etcAnswerCn;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
 
 	/**
      * toString 메소드를 대치한다.
@@ -267,4 +81,5 @@ public class QustnrRespondInfoVO implements Serializable {
     public String toString() {
     	return ToStringBuilder.reflectionToString(this);
     }
+
 }

--- a/src/main/java/egovframework/let/uss/olp/qrm/service/QustnrRespondManageVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qrm/service/QustnrRespondManageVO.java
@@ -6,8 +6,12 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 설문응답자관리 VO Class 구현 
+ * 설문응답자관리 VO Class 구현
  * @author 공통서비스 장동한
  * @since 2009.03.20
  * @version 1.0
@@ -15,7 +19,7 @@ import jakarta.validation.constraints.Pattern;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
@@ -23,8 +27,10 @@ import jakarta.validation.constraints.Pattern;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrRespondManageVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -32,282 +38,58 @@ public class QustnrRespondManageVO implements Serializable {
 
 	/** 설문지ID */
 	private String qestnrId = "";
-	
+
 	/** 설문응답자아이디 */
 	private String qestnrRespondId = "";
-	
+
 	/** 설별코드 */
 	@EgovNullCheck
 	private String sexdstnCode = "";
-	
+
 	/** 직업유형코드 */
 	@EgovNullCheck
 	private String occpTyCode = "";
-	
+
 	/** 응답자명 */
 	@EgovNullCheck
 	@Size(max=50)
 	private String respondNm = "";
-	
+
 	/** 생년월일 */
 	private String brth = "";
-	
+
 	/** 첫번째전화번호 */
 	@EgovNullCheck
 	@Size(max=4)
 	@Pattern(regexp = "^[0-9]*$", message = "{validation.integer.check}")
 	private String areaNo = "";
-	
+
 	/** 두번째전화번호 */
 	@EgovNullCheck
 	@Size(max=4)
 	@Pattern(regexp = "^[0-9]*$", message = "{validation.integer.check}")
 	private String middleTelno = "";
-	
+
 	/** 마지막전화번호 */
 	@EgovNullCheck
 	@Size(max=4)
 	@Pattern(regexp = "^[0-9]*$", message = "{validation.integer.check}")
 	private String endTelno = "";
-	
+
 	/** 최초등록시점 */
 	private String frstRegisterPnttm = "";
-	
+
 	/** 최초등록자ID */
 	private String frstRegisterId = "";
-	
+
 	/** 최종수정시점 */
 	private String lastUpdusrPnttm = "";
-	
+
 	/** 최종수정ID */
 	private String lastUpdusrId = "";
-	
+
 	/** 설문템플릿ID */
 	private String qestnrTmplatId = "";
-
-	/**
-	 * qestnrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrId() {
-		return qestnrId;
-	}
-
-	/**
-	 * qestnrId attribute 값을 설정한다.
-	 * @return qestnrId String
-	 */
-	public void setQestnrId(String qestnrId) {
-		this.qestnrId = qestnrId;
-	}
-
-	/**
-	 * qestnrRespondId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrRespondId() {
-		return qestnrRespondId;
-	}
-
-	/**
-	 * qestnrRespondId attribute 값을 설정한다.
-	 * @return qestnrRespondId String
-	 */
-	public void setQestnrRespondId(String qestnrRespondId) {
-		this.qestnrRespondId = qestnrRespondId;
-	}
-
-	/**
-	 * sexdstnCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSexdstnCode() {
-		return sexdstnCode;
-	}
-
-	/**
-	 * sexdstnCode attribute 값을 설정한다.
-	 * @return sexdstnCode String
-	 */
-	public void setSexdstnCode(String sexdstnCode) {
-		this.sexdstnCode = sexdstnCode;
-	}
-
-	/**
-	 * occpTyCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOccpTyCode() {
-		return occpTyCode;
-	}
-
-	/**
-	 * occpTyCode attribute 값을 설정한다.
-	 * @return occpTyCode String
-	 */
-	public void setOccpTyCode(String occpTyCode) {
-		this.occpTyCode = occpTyCode;
-	}
-
-	/**
-	 * respondNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getRespondNm() {
-		return respondNm;
-	}
-
-	/**
-	 * respondNm attribute 값을 설정한다.
-	 * @return respondNm String
-	 */
-	public void setRespondNm(String respondNm) {
-		this.respondNm = respondNm;
-	}
-
-	/**
-	 * brth attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getBrth() {
-		return brth;
-	}
-
-	/**
-	 * brth attribute 값을 설정한다.
-	 * @return brth String
-	 */
-	public void setBrth(String brth) {
-		this.brth = brth;
-	}
-
-	/**
-	 * areaNo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @return areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-
-	/**
-	 * middleTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getMiddleTelno() {
-		return middleTelno;
-	}
-
-	/**
-	 * middleTelno attribute 값을 설정한다.
-	 * @return middleTelno String
-	 */
-	public void setMiddleTelno(String middleTelno) {
-		this.middleTelno = middleTelno;
-	}
-
-	/**
-	 * endTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEndTelno() {
-		return endTelno;
-	}
-
-	/**
-	 * endTelno attribute 값을 설정한다.
-	 * @return endTelno String
-	 */
-	public void setEndTelno(String endTelno) {
-		this.endTelno = endTelno;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
 
 	/**
      * toString 메소드를 대치한다.
@@ -315,5 +97,5 @@ public class QustnrRespondManageVO implements Serializable {
     public String toString() {
     	return ToStringBuilder.reflectionToString(this);
     }
-	
+
 }

--- a/src/main/java/egovframework/let/uss/olp/qtm/service/QustnrTmplatManageVO.java
+++ b/src/main/java/egovframework/let/uss/olp/qtm/service/QustnrTmplatManageVO.java
@@ -5,8 +5,12 @@ import java.io.Serializable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 설문템플릿 VO Class 구현 
+ * 설문템플릿 VO Class 구현
  * @author 공통서비스 장동한
  * @since 2009.03.20
  * @version 1.0
@@ -14,14 +18,16 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  장동한          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QustnrTmplatManageVO implements Serializable {
 
 	/**
@@ -31,191 +37,39 @@ public class QustnrTmplatManageVO implements Serializable {
 
 	/** 설문템플릿 아이디 */
 	private String qestnrTmplatId = "";
-	
+
 	/** 설문템플릿 유형 */
 	@EgovNullCheck
 	@Size(max=100)
 	private String qestnrTmplatTy = "";
-	
+
 	/** 설문템플 이미지경로 */
-	public byte[] qestnrTmplatImagepathnm;
-	
+	private byte[] qestnrTmplatImagepathnm;
+
 	/** 설문템플릿  설명 */
 	@EgovNullCheck
 	@Size(max=1000)
 	private String qestnrTmplatCn = "";
-	
+
 	/** 서물템플릿경로명 */
 	@EgovNullCheck
 	@Size(max=100)
 	private String qestnrTmplatCours;
-	
+
 	/** 최초등록시점 */
 	private String frstRegisterPnttm = "";
-	
+
 	/** 최초등록자아이디 */
 	private String frstRegisterId = "";
-	
+
 	/** 최종수정자 시점 */
 	private String lastUpdusrPnttm = "";
-	
+
 	/** 최종수정자아이디 */
 	private String lastUpdusrId = "";
-	
+
 	/** 화면 명령 처리 */
 	private String cmd = "";
-
-	/**
-	 * qestnrTmplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatId() {
-		return qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatId attribute 값을 설정한다.
-	 * @return qestnrTmplatId String
-	 */
-	public void setQestnrTmplatId(String qestnrTmplatId) {
-		this.qestnrTmplatId = qestnrTmplatId;
-	}
-
-	/**
-	 * qestnrTmplatTy attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatTy() {
-		return qestnrTmplatTy;
-	}
-
-	/**
-	 * qestnrTmplatTy attribute 값을 설정한다.
-	 * @return qestnrTmplatTy String
-	 */
-	public void setQestnrTmplatTy(String qestnrTmplatTy) {
-		this.qestnrTmplatTy = qestnrTmplatTy;
-	}
-
-	/**
-	 * qestnrTmplatImagepathnm attribute 값을 설정한다.
-	 * @return qestnrTmplatImagepathnm byte[]
-	 */
-	public void setQestnrTmplatImagepathnm(byte[] qestnrTmplatImagepathnm) {
-		this.qestnrTmplatImagepathnm = qestnrTmplatImagepathnm;
-	}
-
-	/**
-	 * qestnrTmplatCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatCn() {
-		return qestnrTmplatCn;
-	}
-
-	/**
-	 * qestnrTmplatCn attribute 값을 설정한다.
-	 * @return qestnrTmplatCn String
-	 */
-	public void setQestnrTmplatCn(String qestnrTmplatCn) {
-		this.qestnrTmplatCn = qestnrTmplatCn;
-	}
-
-	/**
-	 * qestnrTmplatCours attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnrTmplatCours() {
-		return qestnrTmplatCours;
-	}
-
-	/**
-	 * qestnrTmplatCours attribute 값을 설정한다.
-	 * @return qestnrTmplatCours String
-	 */
-	public void setQestnrTmplatCours(String qestnrTmplatCours) {
-		this.qestnrTmplatCours = qestnrTmplatCours;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-	/**
-	 * cmd attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getCmd() {
-		return cmd;
-	}
-
-	/**
-	 * cmd attribute 값을 설정한다.
-	 * @return cmd String
-	 */
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
 
 	/**
      * toString 메소드를 대치한다.
@@ -223,5 +77,5 @@ public class QustnrTmplatManageVO implements Serializable {
     public String toString() {
     	return ToStringBuilder.reflectionToString(this);
     }
-	
+
 }


### PR DESCRIPTION
설문(olp) 모듈 6개 VO의 수동 getter/setter를 Lombok @Getter/@Setter로 대체합니다.

변경 내용:
- `QustnrItemManageVO`, `QustnrManageVO`, `QustnrQestnManageVO`, `QustnrRespondInfoVO`, `QustnrRespondManageVO`, `QustnrTmplatManageVO` — 클래스 레벨 `@Getter`/`@Setter` 적용, 수동 메서드 제거
- `QustnrTmplatManageVO`의 `public byte[]` 필드를 `private`으로 변경 (Lombok setter 생성 대상 포함)
- `ToStringBuilder.reflectionToString` 기반 `toString()` override는 그대로 유지
- `pom.xml` `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 (Lombok APT 활성화)

검증:
- `mvn -DskipTests compile` BUILD SUCCESS 확인

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 테스트 통과 확인
