### PR TITLE
[refactor][portal] sec 패키지 5 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.42</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/sec/gmt/service/GroupManageVO.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/GroupManageVO.java
@@ -2,7 +2,8 @@ package egovframework.let.sec.gmt.service;
 
 import java.util.List;
 
-
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 그룹관리에 대한 Vo 클래스를 정의한다.
@@ -13,15 +14,16 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class GroupManageVO extends GroupManage {
 
 	/**
@@ -30,43 +32,11 @@ public class GroupManageVO extends GroupManage {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 그룹 목록
-	 */	
-	List <GroupManageVO> groupManageList;
+	 */
+	List<GroupManageVO> groupManageList;
 	/**
 	 * 삭제대상 목록
-	 */		
-    String[] delYn;
-
-	/**
-	 * groupManageList attribute 를 리턴한다.
-	 * @return List<GroupManageVO>
 	 */
-	public List<GroupManageVO> getGroupManageList() {
-		return groupManageList;
-	}
-
-	/**
-	 * groupManageList attribute 값을 설정한다.
-	 * @param groupManageList List<GroupManageVO> 
-	 */
-	public void setGroupManageList(List<GroupManageVO> groupManageList) {
-		this.groupManageList = groupManageList;
-	}
-
-	/**
-	 * delYn attribute 를 리턴한다.
-	 * @return String[]
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-
-	/**
-	 * delYn attribute 값을 설정한다.
-	 * @param delYn String[] 
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
+	String[] delYn;
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorManageVO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,37 +14,20 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorManageVO extends AuthorManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorManageVO> authorManageList;
-
-	/**
-	 * authorManageList attribute 를 리턴한다.
-	 * @return List<AuthorManageVO>
-	 */
-	public List<AuthorManageVO> getAuthorManageList() {
-		return authorManageList;
-	}
-
-	/**
-	 * authorManageList attribute 값을 설정한다.
-	 * @param authorManageList List<AuthorManageVO> 
-	 */
-	public void setAuthorManageList(List<AuthorManageVO> authorManageList) {
-		this.authorManageList = authorManageList;
-	}
-
-
+	List<AuthorManageVO> authorManageList;
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManageVO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한별 롤 관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,37 +14,20 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorRoleManageVO extends AuthorRoleManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorRoleManageVO> authorRoleList;
-
-	/**
-	 * authorRoleList attribute 를 리턴한다.
-	 * @return List<AuthorRoleManageVO>
-	 */
-	public List<AuthorRoleManageVO> getAuthorRoleList() {
-		return authorRoleList;
-	}
-
-	/**
-	 * authorRoleList attribute 값을 설정한다.
-	 * @param authorRoleList List<AuthorRoleManageVO> 
-	 */
-	public void setAuthorRoleList(List<AuthorRoleManageVO> authorRoleList) {
-		this.authorRoleList = authorRoleList;
-	}
-
-
+	List<AuthorRoleManageVO> authorRoleList;
 
 }

--- a/src/main/java/egovframework/let/sec/rgm/service/AuthorGroupVO.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/AuthorGroupVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.rgm.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한그룹에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,34 +14,20 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class AuthorGroupVO extends AuthorGroup {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorGroupVO> authorGroupList;
-
-	/**
-	 * authorGroupList attribute 를 리턴한다.
-	 * @return List<AuthorGroupVO>
-	 */
-	public List<AuthorGroupVO> getAuthorGroupList() {
-		return authorGroupList;
-	}
-	/**
-	 * authorGroupList attribute 값을 설정한다.
-	 * @param authorGroupList List<AuthorGroupVO> 
-	 */
-	public void setAuthorGroupList(List<AuthorGroupVO> authorGroupList) {
-		this.authorGroupList = authorGroupList;
-	}
+	List<AuthorGroupVO> authorGroupList;
 
 }

--- a/src/main/java/egovframework/let/sec/rmt/service/RoleManageVO.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/RoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.rmt.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 롤관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,15 +14,16 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
+@Getter
+@Setter
 public class RoleManageVO extends RoleManage {
 	/**
 	 * serialVersionUID
@@ -27,40 +31,11 @@ public class RoleManageVO extends RoleManage {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 롤 목록
-	 */	
-	List <RoleManageVO> roleManageList;
+	 */
+	List<RoleManageVO> roleManageList;
 	/**
 	 * 삭제대상 목록
-	 */		
-    String[] delYn;
+	 */
+	String[] delYn;
 
-	/**
-	 * roleManageList attribute 를 리턴한다.
-	 * @return List<RoleManageVO>
-	 */
-	public List<RoleManageVO> getRoleManageList() {
-		return roleManageList;
-	}
-	/**
-	 * roleManageList attribute 값을 설정한다.
-	 * @param roleManageList List<RoleManageVO> 
-	 */
-	public void setRoleManageList(List<RoleManageVO> roleManageList) {
-		this.roleManageList = roleManageList;
-	}
-	/**
-	 * delYn attribute 를 리턴한다.
-	 * @return String[]
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-	/**
-	 * delYn attribute 값을 설정한다.
-	 * @param delYn String[] 
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
-	
 }


### PR DESCRIPTION
## 변경 사유
portal-site-template의 sec 패키지 5개 VO에 수동 getter/setter가 작성되어 있어
보일러플레이트가 많고 필드 추가시 누락 위험이 있다. Lombok 어노테이션으로 대체.

## 변경 내용
- `GroupManageVO`, `AuthorManageVO`, `AuthorRoleManageVO`, `AuthorGroupVO`, `RoleManageVO` 5개 VO에 `@Getter @Setter` 적용
- 수동 getter/setter 제거, toString/equals/hashCode 보존
- `pom.xml`에 `annotationProcessorPaths` 추가 (Lombok APT 활성화)

## 영향 범위
- 외부 API 변경 없음
- `mvn -DskipTests compile` BUILD SUCCESS

## 체크리스트
- [x] sec 패키지 5 VO만 다룸
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과
- [x] uss/olp(#55) 처리분과 다른 영역
