### PR TITLE
[refactor][portal] uss/olh/faq FAQ 모듈 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageDAO.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageDAO.java
@@ -2,17 +2,18 @@ package egovframework.let.uss.olh.faq.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.olh.faq.service.FaqManageDefaultVO;
 import egovframework.let.uss.olh.faq.service.FaqManageVO;
+import jakarta.annotation.Resource;
+
 /**
  *
  * FAQ를 처리하는 DAO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
- * @version 1.0
+ * @version 2.0
  * @see
  *
  * <pre>
@@ -22,12 +23,15 @@ import egovframework.let.uss.olh.faq.service.FaqManageVO;
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
  *
  * </pre>
  */
 @Repository("FaqManageDAO")
-public class FaqManageDAO extends EgovAbstractMapper {
+public class FaqManageDAO {
 
+    @Resource(name = "faqManageMapper")
+    private FaqManageMapper faqManageMapper;
 
     /**
 	 * FAQ 글 목록에 대한 상세내용을 조회한다.
@@ -36,9 +40,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public FaqManageVO selectFaqListDetail(FaqManageVO vo) throws Exception {
-
-        return (FaqManageVO) selectOne("FaqManageDAO.selectFaqListDetail", vo);
-
+        return faqManageMapper.selectFaqListDetail(vo);
     }
 
 	/**
@@ -47,9 +49,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void updateFaqInqireCo(FaqManageVO vo) throws Exception {
-
-        update("FaqManageDAO.updateFaqInqireCo", vo);
-
+        faqManageMapper.updateFaqInqireCo(vo);
     }
 
     /**
@@ -59,9 +59,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<?> selectFaqList(FaqManageDefaultVO searchVO) throws Exception {
-
-        return selectList("FaqManageDAO.selectFaqList", searchVO);
-
+        return faqManageMapper.selectFaqList(searchVO);
     }
 
     /**
@@ -70,9 +68,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @return 글 총 갯수
 	 */
     public int selectFaqListTotCnt(FaqManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("FaqManageDAO.selectFaqListTotCnt", searchVO);
-
+        return faqManageMapper.selectFaqListTotCnt(searchVO);
     }
 
 	/**
@@ -81,9 +77,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void insertFaqCn(FaqManageVO vo) throws Exception {
-
-        insert("FaqManageDAO.insertFaqCn", vo);
-
+        faqManageMapper.insertFaqCn(vo);
     }
 
 	/**
@@ -92,9 +86,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void updateFaqCn(FaqManageVO vo) throws Exception {
-
-        update("FaqManageDAO.updateFaqCn", vo);
-
+        faqManageMapper.updateFaqCn(vo);
     }
 
 	/**
@@ -103,9 +95,7 @@ public class FaqManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void deleteFaqCn(FaqManageVO vo) throws Exception {
-
-        delete("FaqManageDAO.deleteFaqCn", vo);
-
+        faqManageMapper.deleteFaqCn(vo);
     }
 
 }

--- a/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageMapper.java
@@ -1,0 +1,82 @@
+package egovframework.let.uss.olh.faq.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.olh.faq.service.FaqManageDefaultVO;
+import egovframework.let.uss.olh.faq.service.FaqManageVO;
+
+/**
+ * FAQ를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 2.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  박정규          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("faqManageMapper")
+public interface FaqManageMapper {
+
+    /**
+     * FAQ 글 목록에 대한 상세내용을 조회한다.
+     * @param vo
+     * @return 조회한 글
+     * @exception Exception
+     */
+    FaqManageVO selectFaqListDetail(FaqManageVO vo) throws Exception;
+
+    /**
+     * FAQ 조회수를 수정한다.
+     * @param vo
+     * @exception Exception
+     */
+    void updateFaqInqireCo(FaqManageVO vo) throws Exception;
+
+    /**
+     * FAQ 글 목록을 조회한다.
+     * @param searchVO
+     * @return 글 목록
+     * @exception Exception
+     */
+    List<?> selectFaqList(FaqManageDefaultVO searchVO) throws Exception;
+
+    /**
+     * FAQ 글 총 갯수를 조회한다.
+     * @param searchVO
+     * @return 글 총 갯수
+     */
+    int selectFaqListTotCnt(FaqManageDefaultVO searchVO);
+
+    /**
+     * FAQ 글을 등록한다.
+     * @param vo
+     * @exception Exception
+     */
+    void insertFaqCn(FaqManageVO vo) throws Exception;
+
+    /**
+     * FAQ 글을 수정한다.
+     * @param vo
+     * @exception Exception
+     */
+    void updateFaqCn(FaqManageVO vo) throws Exception;
+
+    /**
+     * FAQ 글을 삭제한다.
+     * @param vo
+     * @exception Exception
+     */
+    void deleteFaqCn(FaqManageVO vo) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">


### PR DESCRIPTION
eGovFrame 5.0에 반영된 `@EgovMapper` 어노테이션 방식을 활용하여 `uss/olh/faq` FAQ 모듈의 XML 매퍼를 인터페이스 기반으로 전환한다.

**변경 내용**

- `FaqManageMapper` 인터페이스 신규 생성 (`@EgovMapper("faqManageMapper")` 어노테이션 적용)
- `FaqManageDAO`: `EgovAbstractMapper` 상속 제거, `@Resource`로 `FaqManageMapper` 주입
- XML 매퍼 5개(mysql/oracle/cubrid/altibase/tibero)의 `namespace`를 `FaqManageDAO` 문자열에서 인터페이스 FQN(`egovframework.let.uss.olh.faq.service.impl.FaqManageMapper`)으로 변경
- SQL 내용 변경 없음

**영향 범위**

- `uss/olh/faq` 모듈만 변경
- 기존 `FaqManageDAO` 메서드 시그니처 유지 — 상위 서비스/컨트롤러 변경 불필요

**체크리스트**

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 의존성 추가 없음
- [x] 기존 동작에 영향 없음 (SQL 변경 없음, DAO 인터페이스 유지)
- [x] FAQ 모듈 컴파일 오류 없음 확인
