### PR TITLE
[refactor][portal] sym/cal, sym/ccm/zip, uss/ion/bnr 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/sym/cal/service/RestdeVO.java
+++ b/src/main/java/egovframework/let/sym/cal/service/RestdeVO.java
@@ -2,10 +2,11 @@ package egovframework.let.sym.cal.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * 
+ *
  * 휴일 VO 클래스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
@@ -14,15 +15,17 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class RestdeVO extends Restde implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -30,19 +33,19 @@ public class RestdeVO extends Restde implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -55,155 +58,4 @@ public class RestdeVO extends Restde implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-    
 }

--- a/src/main/java/egovframework/let/sym/ccm/zip/service/ZipVO.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/ZipVO.java
@@ -2,8 +2,11 @@ package egovframework.let.sym.ccm.zip.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * 우편번호 VO 클래스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
@@ -12,7 +15,7 @@ import java.io.Serializable;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
@@ -20,8 +23,10 @@ import java.io.Serializable;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class ZipVO extends Zip implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -29,19 +34,19 @@ public class ZipVO extends Zip implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -54,149 +59,4 @@ public class ZipVO extends Zip implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-    
 }

--- a/src/main/java/egovframework/let/uss/ion/bnr/service/BannerVO.java
+++ b/src/main/java/egovframework/let/uss/ion/bnr/service/BannerVO.java
@@ -1,6 +1,10 @@
 package egovframework.let.uss.ion.bnr.service;
 
 import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 배너에 대한 Vo 클래스를 정의한다.
  * 배너의 목록 항목을 관리한다.
@@ -11,71 +15,34 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.08.03  lee.m.j        최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class BannerVO extends Banner {
 
 	/**
 	 * serialVersionUID
 	 */
-	private static final long serialVersionUID = 1L;	
-	/**
-	 * 배너 목록
-	 */	
-	List<BannerVO> bannerList;
-	/**
-	 * 삭제대상 목록
-	 */		
-    String[] delYn;
+	private static final long serialVersionUID = 1L;
+
+	/** 배너 목록 */
+	private List<BannerVO> bannerList;
+
+	/** 삭제대상 목록 */
+	private String[] delYn;
+
 	/**
 	 * 결과 반영 타입
 	 * vertical : 세로
 	 * horizontal : 가로
-	 */		
-    String resultType = "horizontal";
+	 */
+	private String resultType = "horizontal";
 
-	/**
-	 * @return the bannerList
-	 */
-	public List<BannerVO> getBannerList() {
-		return bannerList;
-	}
-	/**
-	 * @param bannerList the bannerList to set
-	 */
-	public void setBannerList(List<BannerVO> bannerList) {
-		this.bannerList = bannerList;
-	}
-	/**
-	 * @return the delYn
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-	/**
-	 * @param delYn the delYn to set
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
-	/**
-	 * @return the resultType
-	 */
-	public String getResultType() {
-		return resultType;
-	}
-	/**
-	 * @param resultType the resultType to set
-	 */
-	public void setResultType(String resultType) {
-		this.resultType = resultType;
-	}
-    
-    
 }


### PR DESCRIPTION
## 변경 사유

sym/cal(휴일), sym/ccm/zip(우편번호), uss/ion/bnr(배너) 모듈 VO 클래스에 필드당 getter/setter가 수작업으로 반복 선언되어 있어 코드 가독성이 낮고 유지보수 비용이 높습니다. pom.xml에 Lombok이 이미 `provided` scope로 등록되어 있어 즉시 활용 가능합니다.

## 변경 내용

| 클래스 | 위치 | 제거된 접근자 수 |
|---|---|---|
| `RestdeVO` | sym/cal | 18개 (9필드 × getter+setter) |
| `ZipVO` | sym/ccm/zip | 18개 (9필드 × getter+setter) |
| `BannerVO` | uss/ion/bnr | 6개 (3필드 × getter+setter) + 필드 접근제어자 private 명시 |
| **합계** | | **42개** |

- 각 클래스에 `@Getter`, `@Setter` 클래스 레벨 어노테이션 추가
- `serialVersionUID` 유지
- pom.xml `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 (Lombok annotation processor 명시적 등록)

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 메서드 시그니처 동일)
- [x] 빌드 통과 확인 (`mvn compile` BUILD SUCCESS)
