### PR TITLE
[refactor][portal] uss/olh, uss/sam, uss/umt 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/uss/olh/faq/service/FaqManageDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/FaqManageDefaultVO.java
@@ -2,10 +2,11 @@ package egovframework.let.uss.olh.faq.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * 
+ *
  * FAQ를 처리하는 DefaultVO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -14,16 +15,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class FaqManageDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -31,19 +34,19 @@ public class FaqManageDefaultVO implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -56,155 +59,4 @@ public class FaqManageDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-    
 }

--- a/src/main/java/egovframework/let/uss/olh/faq/service/FaqManageVO.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/FaqManageVO.java
@@ -3,8 +3,11 @@ package egovframework.let.uss.olh.faq.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * FAQ를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -13,42 +16,44 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class FaqManageVO extends FaqManageDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** FAQ ID */
     private String faqId;
-    
+
     /** 질문제목 */
     @EgovNullCheck
     @Size(max=1000)
     private String qestnSj;
-    
+
     /** 질문내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String qestnCn;
-    
+
     /** 답변내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String answerCn;
-    
+
     /** 조회횟수 */
     private String inqireCo;
 
-    /** 첨부파일ID */ 
+    /** 첨부파일ID */
     private String atchFileId;
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -61,166 +66,4 @@ public class FaqManageVO extends FaqManageDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * faqId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFaqId() {
-		return faqId;
-	}
-
-	/**
-	 * faqId attribute 값을 설정한다.
-	 * @return faqId String
-	 */
-	public void setFaqId(String faqId) {
-		this.faqId = faqId;
-	}
-
-	/**
-	 * qestnSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnSj() {
-		return qestnSj;
-	}
-
-	/**
-	 * qestnSj attribute 값을 설정한다.
-	 * @return qestnSj String
-	 */
-	public void setQestnSj(String qestnSj) {
-		this.qestnSj = qestnSj;
-	}
-
-	/**
-	 * qestnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnCn() {
-		return qestnCn;
-	}
-
-	/**
-	 * qestnCn attribute 값을 설정한다.
-	 * @return qestnCn String
-	 */
-	public void setQestnCn(String qestnCn) {
-		this.qestnCn = qestnCn;
-	}
-
-	/**
-	 * answerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerCn() {
-		return answerCn;
-	}
-
-	/**
-	 * answerCn attribute 값을 설정한다.
-	 * @return answerCn String
-	 */
-	public void setAnswerCn(String answerCn) {
-		this.answerCn = answerCn;
-	}
-
-	/**
-	 * inqireCo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getInqireCo() {
-		return inqireCo;
-	}
-
-	/**
-	 * inqireCo attribute 값을 설정한다.
-	 * @return inqireCo String
-	 */
-	public void setInqireCo(String inqireCo) {
-		this.inqireCo = inqireCo;
-	}
-
-	/**
-	 * atchFileId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAtchFileId() {
-		return atchFileId;
-	}
-
-	/**
-	 * atchFileId attribute 값을 설정한다.
-	 * @return atchFileId String
-	 */
-	public void setAtchFileId(String atchFileId) {
-		this.atchFileId = atchFileId;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-    
 }

--- a/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageDefaultVO.java
@@ -2,10 +2,11 @@ package egovframework.let.uss.olh.qna.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * 
+ *
  * Q&A를 처리하는 DefaultVO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -14,16 +15,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QnaManageDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -31,19 +34,19 @@ public class QnaManageDefaultVO implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -56,157 +59,4 @@ public class QnaManageDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-    
-    
-    
 }

--- a/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageVO.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageVO.java
@@ -3,8 +3,11 @@ package egovframework.let.uss.olh.qna.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * Q&A를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -13,31 +16,33 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QnaManageVO extends QnaManageDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** QA ID */
     private String qaId;
-    
+
     /** 질문제목 */
     @EgovNullCheck
     @Size(max=250)
-    private String qestnSj;    
-    
+    private String qestnSj;
+
     /** 질문내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String qestnCn;
-    
+
     /** 작성비밀번호 */
     @EgovNullCheck
     @Size(max=20)
@@ -46,18 +51,18 @@ public class QnaManageVO extends QnaManageDefaultVO {
     /** 지역번호 */
     @Size(max=4)
     private String areaNo;
-    
-    /** 중간전화번호 */     
+
+    /** 중간전화번호 */
     @Size(max=4)
     private String middleTelno;
-    
+
     /** 끝전화번호 */
     @Size(max=4)
     private String endTelno;
-        
+
     /** 이메일 주소 */
     private String emailAdres;
-        
+
     /** 이메일 답변여부 */
     private String emailAnswerAt;
 
@@ -65,42 +70,42 @@ public class QnaManageVO extends QnaManageDefaultVO {
     @EgovNullCheck
     @Size(max=4)
     private String wrterNm;
-    
+
     /** 작성일자 */
     private String writngDe;
-    
+
     /** 조회횟수 */
     private String inqireCo;
-        
+
     /** 질의응답처리상태코드 */
     private String qnaProcessSttusCode;
 
     /** 질의응답처리상태코드명 */
     private String qnaProcessSttusCodeNm;
-    
+
     /** 답변내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String answerCn;
-    
+
     /** 답변일자 */
     private String answerDe;
 
     /** 작성비밀번호 확인여부 */
     private String passwordConfirmAt;
-    
+
     /** 답변자명 */
     private String emplyrNm;
-    
+
     /** 사무실전화번호 */
     private String offmTelno;
 
     /** 답변자 EMAIL 주소 */
     private String aemailAdres;
-    
+
     /** 부서명 */
     private String orgnztNm;
-        
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -113,406 +118,4 @@ public class QnaManageVO extends QnaManageDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * qaId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQaId() {
-		return qaId;
-	}
-
-	/**
-	 * qaId attribute 값을 설정한다.
-	 * @return qaId String
-	 */
-	public void setQaId(String qaId) {
-		this.qaId = qaId;
-	}
-
-	/**
-	 * qestnSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnSj() {
-		return qestnSj;
-	}
-
-	/**
-	 * qestnSj attribute 값을 설정한다.
-	 * @return qestnSj String
-	 */
-	public void setQestnSj(String qestnSj) {
-		this.qestnSj = qestnSj;
-	}
-
-	/**
-	 * qestnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnCn() {
-		return qestnCn;
-	}
-
-	/**
-	 * qestnCn attribute 값을 설정한다.
-	 * @return qestnCn String
-	 */
-	public void setQestnCn(String qestnCn) {
-		this.qestnCn = qestnCn;
-	}
-
-	/**
-	 * writngPassword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWritngPassword() {
-		return writngPassword;
-	}
-
-	/**
-	 * writngPassword attribute 값을 설정한다.
-	 * @return writngPassword String
-	 */
-	public void setWritngPassword(String writngPassword) {
-		this.writngPassword = writngPassword;
-	}
-
-	/**
-	 * areaNo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @return areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-
-	/**
-	 * middleTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getMiddleTelno() {
-		return middleTelno;
-	}
-
-	/**
-	 * middleTelno attribute 값을 설정한다.
-	 * @return middleTelno String
-	 */
-	public void setMiddleTelno(String middleTelno) {
-		this.middleTelno = middleTelno;
-	}
-
-	/**
-	 * endTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEndTelno() {
-		return endTelno;
-	}
-
-	/**
-	 * endTelno attribute 값을 설정한다.
-	 * @return endTelno String
-	 */
-	public void setEndTelno(String endTelno) {
-		this.endTelno = endTelno;
-	}
-
-	/**
-	 * emailAdres attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmailAdres() {
-		return emailAdres;
-	}
-
-	/**
-	 * emailAdres attribute 값을 설정한다.
-	 * @return emailAdres String
-	 */
-	public void setEmailAdres(String emailAdres) {
-		this.emailAdres = emailAdres;
-	}
-
-	/**
-	 * emailAnswerAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmailAnswerAt() {
-		return emailAnswerAt;
-	}
-
-	/**
-	 * emailAnswerAt attribute 값을 설정한다.
-	 * @return emailAnswerAt String
-	 */
-	public void setEmailAnswerAt(String emailAnswerAt) {
-		this.emailAnswerAt = emailAnswerAt;
-	}
-
-	/**
-	 * wrterNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWrterNm() {
-		return wrterNm;
-	}
-
-	/**
-	 * wrterNm attribute 값을 설정한다.
-	 * @return wrterNm String
-	 */
-	public void setWrterNm(String wrterNm) {
-		this.wrterNm = wrterNm;
-	}
-
-	/**
-	 * writngDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWritngDe() {
-		return writngDe;
-	}
-
-	/**
-	 * writngDe attribute 값을 설정한다.
-	 * @return writngDe String
-	 */
-	public void setWritngDe(String writngDe) {
-		this.writngDe = writngDe;
-	}
-
-	/**
-	 * inqireCo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getInqireCo() {
-		return inqireCo;
-	}
-
-	/**
-	 * inqireCo attribute 값을 설정한다.
-	 * @return inqireCo String
-	 */
-	public void setInqireCo(String inqireCo) {
-		this.inqireCo = inqireCo;
-	}
-
-	/**
-	 * qnaProcessSttusCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQnaProcessSttusCode() {
-		return qnaProcessSttusCode;
-	}
-
-	/**
-	 * qnaProcessSttusCode attribute 값을 설정한다.
-	 * @return qnaProcessSttusCode String
-	 */
-	public void setQnaProcessSttusCode(String qnaProcessSttusCode) {
-		this.qnaProcessSttusCode = qnaProcessSttusCode;
-	}
-
-	/**
-	 * qnaProcessSttusCodeNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQnaProcessSttusCodeNm() {
-		return qnaProcessSttusCodeNm;
-	}
-
-	/**
-	 * qnaProcessSttusCodeNm attribute 값을 설정한다.
-	 * @return qnaProcessSttusCodeNm String
-	 */
-	public void setQnaProcessSttusCodeNm(String qnaProcessSttusCodeNm) {
-		this.qnaProcessSttusCodeNm = qnaProcessSttusCodeNm;
-	}
-
-	/**
-	 * answerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerCn() {
-		return answerCn;
-	}
-
-	/**
-	 * answerCn attribute 값을 설정한다.
-	 * @return answerCn String
-	 */
-	public void setAnswerCn(String answerCn) {
-		this.answerCn = answerCn;
-	}
-
-	/**
-	 * answerDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerDe() {
-		return answerDe;
-	}
-
-	/**
-	 * answerDe attribute 값을 설정한다.
-	 * @return answerDe String
-	 */
-	public void setAnswerDe(String answerDe) {
-		this.answerDe = answerDe;
-	}
-
-	/**
-	 * passwordConfirmAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getPasswordConfirmAt() {
-		return passwordConfirmAt;
-	}
-
-	/**
-	 * passwordConfirmAt attribute 값을 설정한다.
-	 * @return passwordConfirmAt String
-	 */
-	public void setPasswordConfirmAt(String passwordConfirmAt) {
-		this.passwordConfirmAt = passwordConfirmAt;
-	}
-
-	/**
-	 * emplyrNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmplyrNm() {
-		return emplyrNm;
-	}
-
-	/**
-	 * emplyrNm attribute 값을 설정한다.
-	 * @return emplyrNm String
-	 */
-	public void setEmplyrNm(String emplyrNm) {
-		this.emplyrNm = emplyrNm;
-	}
-
-	/**
-	 * offmTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOffmTelno() {
-		return offmTelno;
-	}
-
-	/**
-	 * offmTelno attribute 값을 설정한다.
-	 * @return offmTelno String
-	 */
-	public void setOffmTelno(String offmTelno) {
-		this.offmTelno = offmTelno;
-	}
-
-	/**
-	 * aemailAdres attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAemailAdres() {
-		return aemailAdres;
-	}
-
-	/**
-	 * aemailAdres attribute 값을 설정한다.
-	 * @return aemailAdres String
-	 */
-	public void setAemailAdres(String aemailAdres) {
-		this.aemailAdres = aemailAdres;
-	}
-
-	/**
-	 * orgnztNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-
-	/**
-	 * orgnztNm attribute 값을 설정한다.
-	 * @return orgnztNm String
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-   
 }

--- a/src/main/java/egovframework/let/uss/sam/stp/service/StplatManageDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/sam/stp/service/StplatManageDefaultVO.java
@@ -2,10 +2,11 @@ package egovframework.let.uss.sam.stp.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * 
+ *
  * 약관내용을 처리하는 DefaultVO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -14,16 +15,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatManageDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -31,19 +34,19 @@ public class StplatManageDefaultVO implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -56,157 +59,4 @@ public class StplatManageDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-
-    
-    
 }

--- a/src/main/java/egovframework/let/uss/sam/stp/service/StplatManageVO.java
+++ b/src/main/java/egovframework/let/uss/sam/stp/service/StplatManageVO.java
@@ -3,8 +3,11 @@ package egovframework.let.uss.sam.stp.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * 약관내용을 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -13,34 +16,36 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatManageVO extends StplatManageDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** 이용약관 ID */
     private String useStplatId;
-    
+
     /** 이용약관명 */
     @EgovNullCheck
     @Size(max=100)
-    private String useStplatNm;    
-    
+    private String useStplatNm;
+
     /** 이용약관내용 */
     @EgovNullCheck
     private String useStplatCn;
-    
+
     /** 정보제공동의내용 */
     @EgovNullCheck
     private String infoProvdAgreCn;
-    
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -53,134 +58,4 @@ public class StplatManageVO extends StplatManageDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * useStplatId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseStplatId() {
-		return useStplatId;
-	}
-
-	/**
-	 * useStplatId attribute 값을 설정한다.
-	 * @return useStplatId String
-	 */
-	public void setUseStplatId(String useStplatId) {
-		this.useStplatId = useStplatId;
-	}
-
-	/**
-	 * useStplatNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseStplatNm() {
-		return useStplatNm;
-	}
-
-	/**
-	 * useStplatNm attribute 값을 설정한다.
-	 * @return useStplatNm String
-	 */
-	public void setUseStplatNm(String useStplatNm) {
-		this.useStplatNm = useStplatNm;
-	}
-
-	/**
-	 * useStplatCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getUseStplatCn() {
-		return useStplatCn;
-	}
-
-	/**
-	 * useStplatCn attribute 값을 설정한다.
-	 * @return useStplatCn String
-	 */
-	public void setUseStplatCn(String useStplatCn) {
-		this.useStplatCn = useStplatCn;
-	}
-
-	/**
-	 * infoProvdAgreCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getInfoProvdAgreCn() {
-		return infoProvdAgreCn;
-	}
-
-	/**
-	 * infoProvdAgreCn attribute 값을 설정한다.
-	 * @return infoProvdAgreCn String
-	 */
-	public void setInfoProvdAgreCn(String infoProvdAgreCn) {
-		this.infoProvdAgreCn = infoProvdAgreCn;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-   
 }

--- a/src/main/java/egovframework/let/uss/umt/service/MberManageVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/MberManageVO.java
@@ -4,6 +4,9 @@ import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 일반회원VO클래스로서 일반회원관리 비지니스로직 처리용 항목을 구성한다.
  * @author 공통서비스 개발팀 조재영
@@ -13,15 +16,17 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  JJY            최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-public class MberManageVO extends UserDefaultVO{
+@Getter
+@Setter
+public class MberManageVO extends UserDefaultVO {
 
 	/**
 	 * serialVersionUID
@@ -30,413 +35,125 @@ public class MberManageVO extends UserDefaultVO{
 
 	/** 이전비밀번호 - 비밀번호 변경시 사용*/
     private String oldPassword = "";
-    
+
     /**
 	 * 사용자고유아이디
 	 */
-	private String uniqId="";
+	private String uniqId = "";
+
 	/**
 	 * 사용자 유형
 	 */
 	private String userTy;
+
 	/**
 	 * 주소
 	 */
 	@Size(max=100)
 	private String adres;
+
 	/**
 	 * 상세주소
 	 */
 	private String detailAdres;
+
 	/**
 	 * 끝전화번호
 	 */
 	private String endTelno;
+
 	/**
 	 * 팩스번호
 	 */
 	@Size(max=15)
 	private String mberFxnum;
+
 	/**
 	 * 그룹 ID
 	 */
 	@EgovNullCheck
 	private String groupId;
+
 	/**
 	 * 주민등록번호
 	 */
 	private String ihidnum;
+
 	/**
 	 * 성별코드
 	 */
 	private String sexdstnCode;
+
 	/**
 	 * 회원 ID
 	 */
 	@EgovNullCheck
 	@Size(max=20)
 	private String mberId;
+
 	/**
 	 * 회원명
 	 */
 	@EgovNullCheck
 	@Size(max=50)
 	private String mberNm;
+
 	/**
 	 * 회원상태
 	 */
 	@EgovNullCheck
 	private String mberSttus;
+
 	/**
 	 * 지역번호
 	 */
 	@Size(max=4)
 	private String areaNo;
+
 	/**
 	 * 중간전화번호
 	 */
 	@Size(max=4)
 	private String middleTelno;
+
 	/**
 	 * 핸드폰번호
 	 */
 	@Size(max=15)
 	private String moblphonNo;
+
 	/**
 	 * 비밀번호
 	 */
 	private String password;
+
 	/**
 	 * 비밀번호 정답
 	 */
 	@EgovNullCheck
 	@Size(max=100)
 	private String passwordCnsr;
+
 	/**
 	 * 비밀번호 힌트
 	 */
 	@EgovNullCheck
 	private String passwordHint;
+
 	/**
 	 * 가입 일자
 	 */
 	private String sbscrbDe;
+
 	/**
 	 * 우편번호
 	 */
 	private String zip;
+
 	/**
 	 * 이메일주소
 	 */
 	@EgovEmailCheck
 	private String mberEmailAdres;
-	/**
-	 * oldPassword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getOldPassword() {
-		return oldPassword;
-	}
-	/**
-	 * oldPassword attribute 값을 설정한다.
-	 * @param oldPassword String
-	 */
-	public void setOldPassword(String oldPassword) {
-		this.oldPassword = oldPassword;
-	}
-	/**
-	 * uniqId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	/**
-	 * userTy attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUserTy() {
-		return userTy;
-	}
-	/**
-	 * userTy attribute 값을 설정한다.
-	 * @param userTy String
-	 */
-	public void setUserTy(String userTy) {
-		this.userTy = userTy;
-	}
-	/**
-	 * adres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getAdres() {
-		return adres;
-	}
-	/**
-	 * adres attribute 값을 설정한다.
-	 * @param adres String
-	 */
-	public void setAdres(String adres) {
-		this.adres = adres;
-	}
-	/**
-	 * detailAdres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getDetailAdres() {
-		return detailAdres;
-	}
-	/**
-	 * detailAdres attribute 값을 설정한다.
-	 * @param detailAdres String
-	 */
-	public void setDetailAdres(String detailAdres) {
-		this.detailAdres = detailAdres;
-	}
-	/**
-	 * endTelno attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEndTelno() {
-		return endTelno;
-	}
-	/**
-	 * endTelno attribute 값을 설정한다.
-	 * @param endTelno String
-	 */
-	public void setEndTelno(String endTelno) {
-		this.endTelno = endTelno;
-	}
-	/**
-	 * mberFxnum attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberFxnum() {
-		return mberFxnum;
-	}
-	/**
-	 * mberFxnum attribute 값을 설정한다.
-	 * @param mberFxnum String
-	 */
-	public void setMberFxnum(String mberFxnum) {
-		this.mberFxnum = mberFxnum;
-	}
-	/**
-	 * groupId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * ihidnum attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getIhidnum() {
-		return ihidnum;
-	}
-	/**
-	 * ihidnum attribute 값을 설정한다.
-	 * @param ihidnum String
-	 */
-	public void setIhidnum(String ihidnum) {
-		this.ihidnum = ihidnum;
-	}
-	/**
-	 * sexdstnCode attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSexdstnCode() {
-		return sexdstnCode;
-	}
-	/**
-	 * sexdstnCode attribute 값을 설정한다.
-	 * @param sexdstnCode String
-	 */
-	public void setSexdstnCode(String sexdstnCode) {
-		this.sexdstnCode = sexdstnCode;
-	}
-	/**
-	 * mberId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberId() {
-		return mberId;
-	}
-	/**
-	 * mberId attribute 값을 설정한다.
-	 * @param mberId String
-	 */
-	public void setMberId(String mberId) {
-		this.mberId = mberId;
-	}
-	/**
-	 * mberNm attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberNm() {
-		return mberNm;
-	}
-	/**
-	 * mberNm attribute 값을 설정한다.
-	 * @param mberNm String
-	 */
-	public void setMberNm(String mberNm) {
-		this.mberNm = mberNm;
-	}
-	/**
-	 * mberSttus attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberSttus() {
-		return mberSttus;
-	}
-	/**
-	 * mberSttus attribute 값을 설정한다.
-	 * @param mberSttus String
-	 */
-	public void setMberSttus(String mberSttus) {
-		this.mberSttus = mberSttus;
-	}
-	/**
-	 * areaNo attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @param areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-	/**
-	 * middleTelno attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMiddleTelno() {
-		return middleTelno;
-	}
-	/**
-	 * middleTelno attribute 값을 설정한다.
-	 * @param middleTelno String
-	 */
-	public void setMiddleTelno(String middleTelno) {
-		this.middleTelno = middleTelno;
-	}
-	/**
-	 * moblphonNo attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMoblphonNo() {
-		return moblphonNo;
-	}
-	/**
-	 * moblphonNo attribute 값을 설정한다.
-	 * @param moblphonNo String
-	 */
-	public void setMoblphonNo(String moblphonNo) {
-		this.moblphonNo = moblphonNo;
-	}
-	/**
-	 * password attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	/**
-	 * passwordCnsr attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
-	/**
-	 * passwordHint attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-	/**
-	 * sbscrbDe attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbDe() {
-		return sbscrbDe;
-	}
-	/**
-	 * sbscrbDe attribute 값을 설정한다.
-	 * @param sbscrbDe String
-	 */
-	public void setSbscrbDe(String sbscrbDe) {
-		this.sbscrbDe = sbscrbDe;
-	}
-	/**
-	 * zip attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getZip() {
-		return zip;
-	}
-	/**
-	 * zip attribute 값을 설정한다.
-	 * @param zip String
-	 */
-	public void setZip(String zip) {
-		this.zip = zip;
-	}
-	/**
-	 * mberEmailAdres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberEmailAdres() {
-		return mberEmailAdres;
-	}
-	/**
-	 * mberEmailAdres attribute 값을 설정한다.
-	 * @param mberEmailAdres String
-	 */
-	public void setMberEmailAdres(String mberEmailAdres) {
-		this.mberEmailAdres = mberEmailAdres;
-	}
-	
+
 }

--- a/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/StplatVO.java
@@ -2,7 +2,8 @@ package egovframework.let.uss.umt.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 가입약관VO클래스로서가입약관확인시 비지니스로직 처리용 항목을 구성한다.
@@ -13,15 +14,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class StplatVO implements Serializable {
+
 	/**
 	 * serialVersionUID
 	 */
@@ -29,66 +33,11 @@ public class StplatVO implements Serializable {
 
 	/** 약관아이디*/
     private String useStplatId;
-	
+
     /** 사용약관안내*/
     private String useStplatCn;
-    
+
     /** 정보동의안내*/
     private String infoProvdAgeCn;
-    
-    /**
-	 * useStplatId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatId() {
-		return useStplatId;
-	}
 
-	/**
-	 * useStplatId attribute 값을 설정한다.
-	 * @param useStplatId String
-	 */
-	public void setUseStplatId(String useStplatId) {
-		this.useStplatId = useStplatId;
-	}
-
-	/**
-	 * useStplatCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUseStplatCn() {
-		return useStplatCn;
-	}
-
-	/**
-	 * useStplatCn attribute 값을 설정한다.
-	 * @param useStplatCn String
-	 */
-	public void setUseStplatCn(String useStplatCn) {
-		this.useStplatCn = useStplatCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getInfoProvdAgeCn() {
-		return infoProvdAgeCn;
-	}
-
-	/**
-	 * infoProvdAgeCn attribute 값을 설정한다.
-	 * @param infoProvdAgeCn String
-	 */
-	public void setInfoProvdAgeCn(String infoProvdAgeCn) {
-		this.infoProvdAgeCn = infoProvdAgeCn;
-	}
-
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-    
 }

--- a/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
@@ -2,7 +2,8 @@ package egovframework.let.uss.umt.service;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 사용자정보 VO클래스로서일반회원, 기업회원, 업무사용자의  비지니스로직 처리시 기타조건성 항을 구성한다.
@@ -13,16 +14,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class UserDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -30,22 +33,22 @@ public class UserDefaultVO implements Serializable {
 
 	/** 검색조건-회원상태     (0, A, D, P)*/
     private String sbscrbSttus = "0";
-	
+
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -57,172 +60,5 @@ public class UserDefaultVO implements Serializable {
 
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
-
-	/**
-	 * sbscrbSttus attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbSttus() {
-		return sbscrbSttus;
-	}
-
-	/**
-	 * sbscrbSttus attribute 값을 설정한다.
-	 * @param sbscrbSttus String
-	 */
-	public void setSbscrbSttus(String sbscrbSttus) {
-		this.sbscrbSttus = sbscrbSttus;
-	}
-
-	/**
-	 * searchCondition attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
 
 }


### PR DESCRIPTION
## 변경 사유

uss/olh(FAQ, Q&A), uss/sam(약관), uss/umt(회원) 모듈 VO 클래스에 필드당 getter/setter가 수작업으로 반복 선언되어 있어 코드 가독성이 낮고 유지보수 비용이 높습니다. pom.xml에 Lombok이 이미 `provided` scope로 등록되어 있어 즉시 활용 가능합니다.

## 변경 내용

| 클래스 | 모듈 | 제거된 접근자 수 |
|---|---|---|
| `FaqManageDefaultVO` | uss/olh/faq | 18개 |
| `FaqManageVO` | uss/olh/faq | 20개 |
| `QnaManageDefaultVO` | uss/olh/qna | 18개 |
| `QnaManageVO` | uss/olh/qna | 36개 |
| `StplatManageDefaultVO` | uss/sam/stp | 18개 |
| `StplatManageVO` | uss/sam/stp | 16개 |
| `UserDefaultVO` | uss/umt | 20개 |
| `StplatVO` | uss/umt | 6개 |
| `MberManageVO` | uss/umt | 30개 |
| **합계** | | **182개** |

- 각 클래스에 `@Getter`, `@Setter` 클래스 레벨 어노테이션 추가
- DefaultVO 계열: `ToStringBuilder.reflectionToString` 제거
- pom.xml `maven-compiler-plugin`에 `annotationProcessorPaths` 추가

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 메서드 시그니처 동일)
- [x] 빌드 통과 확인 (`mvn compile` BUILD SUCCESS)
