### PR TITLE
[refactor][portal] com/cmm 패키지 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/IncludedCompInfoVO.java
+++ b/src/main/java/egovframework/com/cmm/IncludedCompInfoVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.cmm;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * IncludedInfo annotation을 바탕으로 화면에 표시할 정보를 구성하기 위한 VO 클래스
  * @author 공통컴포넌트 정진오
@@ -9,42 +12,20 @@ package egovframework.com.cmm;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *  수정일		수정자		수정내용
  *  -------    	--------    ---------------------------
  *  2011.08.26	정진오 		최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class IncludedCompInfoVO {
-	
+
 	private String name;
 	private String listUrl;
 	private int order;
 	private int gid;
-	
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getListUrl() {
-		return listUrl;
-	}
-	public void setListUrl(String listUrl) {
-		this.listUrl = listUrl;
-	}
-	public int getOrder() {
-		return order;
-	}
-	public void setOrder(int order) {
-		this.order = order;
-	}
-	public int getGid() {
-		return gid;
-	}
-	public void setGid(int gid) {
-		this.gid = gid;
-	}
+
 }

--- a/src/main/java/egovframework/com/cmm/SessionVO.java
+++ b/src/main/java/egovframework/com/cmm/SessionVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 세션 VO 클래스
  * @author 공통서비스 개발팀 박지욱
@@ -18,6 +21,8 @@ import java.io.Serializable;
  *
  *  </pre>
  */
+@Getter
+@Setter
 public class SessionVO implements Serializable {
 
 	private static final long serialVersionUID = -2848741427493626376L;
@@ -33,88 +38,5 @@ public class SessionVO implements Serializable {
 	private String orgnztId;
 	/** 고유아이디 */
 	private String uniqId;
-	/**
-	 * sUserId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserId() {
-		return sUserId;
-	}
-	/**
-	 * sUserId attribute 값을 설정한다.
-	 * @param sUserId String
-	 */
-	public void setSUserId(String userId) {
-		sUserId = userId;
-	}
-	/**
-	 * sUserNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserNm() {
-		return sUserNm;
-	}
-	/**
-	 * sUserNm attribute 값을 설정한다.
-	 * @param sUserNm String
-	 */
-	public void setSUserNm(String userNm) {
-		sUserNm = userNm;
-	}
-	/**
-	 * sEmail attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSEmail() {
-		return sEmail;
-	}
-	/**
-	 * sEmail attribute 값을 설정한다.
-	 * @param sEmail String
-	 */
-	public void setSEmail(String email) {
-		sEmail = email;
-	}
-	/**
-	 * sUserSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserSe() {
-		return sUserSe;
-	}
-	/**
-	 * sUserSe attribute 값을 설정한다.
-	 * @param sUserSe String
-	 */
-	public void setSUserSe(String userSe) {
-		sUserSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
+
 }


### PR DESCRIPTION
com/cmm 패키지의 IncludedCompInfoVO, SessionVO에 Lombok @Getter/@Setter를 적용하여 반복적인 보일러플레이트 getter/setter 코드를 제거합니다.

변경 내용:
- `IncludedCompInfoVO`: 4개 필드(name, listUrl, order, gid)의 getter/setter를 @Getter/@Setter로 대체
- `SessionVO`: 6개 필드(sUserId, sUserNm, sEmail, sUserSe, orgnztId, uniqId)의 getter/setter를 @Getter/@Setter로 대체

Lombok 의존성은 pom.xml에 이미 포함되어 있으며, 기존 메서드 시그니처와 동작은 동일하게 유지됩니다.

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 빌드 통과 확인 (mvn compile)
