### PR TITLE
[refactor][portal] uss/olh/qna 모듈 @EgovMapper 인터페이스 추가

### DIFF
--- a/src/main/java/egovframework/let/uss/olh/qna/service/impl/EgovQnaManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/impl/EgovQnaManageMapper.java
@@ -1,0 +1,120 @@
+package egovframework.let.uss.olh.qna.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.olh.qna.service.QnaManageDefaultVO;
+import egovframework.let.uss.olh.qna.service.QnaManageVO;
+
+/**
+ * Q&A정보를 처리하는 매퍼 인터페이스
+ *
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  박정규          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2025.05.28  표준프레임워크센터   @EgovMapper 어노테이션 방식으로 추가
+ *
+ * </pre>
+ */
+@EgovMapper("QnaManageDAO")
+public interface EgovQnaManageMapper {
+
+    /**
+     * Q&A 글 목록에 대한 상세내용을 조회한다.
+     * @param vo
+     * @return 조회한 글
+     * @exception Exception
+     */
+    QnaManageVO selectQnaListDetail(QnaManageVO vo) throws Exception;
+
+    /**
+     * Q&A 글을 수정한다.(조회수를 수정)
+     * @param vo
+     * @exception Exception
+     */
+    void updateQnaInqireCo(QnaManageVO vo) throws Exception;
+
+    /**
+     * Q&A 글 목록을 조회한다.
+     * @param searchVO
+     * @return 글 목록
+     * @exception Exception
+     */
+    List<?> selectQnaList(QnaManageDefaultVO searchVO) throws Exception;
+
+    /**
+     * Q&A 글 총 갯수를 조회한다.
+     * @param searchVO
+     * @return 글 총 갯수
+     */
+    int selectQnaListTotCnt(QnaManageDefaultVO searchVO);
+
+    /**
+     * Q&A 글을 등록한다.
+     * @param vo
+     * @exception Exception
+     */
+    void insertQnaCn(QnaManageVO vo) throws Exception;
+
+    /**
+     * 작성비밀번호를 확인한다.
+     * @param vo
+     * @return 글 총 갯수
+     */
+    int selectQnaPasswordConfirmCnt(QnaManageVO vo);
+
+    /**
+     * Q&A 글을 수정한다.
+     * @param vo
+     * @exception Exception
+     */
+    void updateQnaCn(QnaManageVO vo) throws Exception;
+
+    /**
+     * Q&A 글을 삭제한다.
+     * @param vo
+     * @exception Exception
+     */
+    void deleteQnaCn(QnaManageVO vo) throws Exception;
+
+    /**
+     * Q&A 답변 글 목록에 대한 상세내용을 조회한다.
+     * @param vo
+     * @return 조회한 글
+     * @exception Exception
+     */
+    QnaManageVO selectQnaAnswerListDetail(QnaManageVO vo) throws Exception;
+
+    /**
+     * Q&A 답변 글 목록을 조회한다.
+     * @param searchVO
+     * @return 글 목록
+     * @exception Exception
+     */
+    List<?> selectQnaAnswerList(QnaManageDefaultVO searchVO) throws Exception;
+
+    /**
+     * Q&A 답변 글 총 갯수를 조회한다.
+     * @param searchVO
+     * @return 글 총 갯수
+     */
+    int selectQnaAnswerListTotCnt(QnaManageDefaultVO searchVO);
+
+    /**
+     * Q&A 답변 글을 수정한다.
+     * @param vo
+     * @exception Exception
+     */
+    void updateQnaCnAnswer(QnaManageVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olh/qna/service/impl/EgovQnaManageServiceImpl.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/impl/EgovQnaManageServiceImpl.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Resource;
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
  *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2025.05.28  표준프레임워크센터   EgovQnaManageMapper(@EgovMapper) 추가
  *
  * </pre>
  */
@@ -35,6 +36,9 @@ public class EgovQnaManageServiceImpl extends EgovAbstractServiceImpl implements
 
     @Resource(name="QnaManageDAO")
     private QnaManageDAO qnaManageDAO;
+
+    @Resource(name="QnaManageDAO")
+    private EgovQnaManageMapper qnaManageMapper;
 
     /** ID Generation */
 	@Resource(name="egovQnaManageIdGnrService")


### PR DESCRIPTION
## 변경 사유

eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식을 포털 사이트 템플릿의 Q&A 모듈에 적용한다.
기존 `EgovAbstractMapper` 상속 방식(QnaManageDAO)은 그대로 유지하고, 인터페이스 기반 매퍼를 병행 제공하여 점진적 전환을 지원한다.

## 변경 내용

- `EgovQnaManageMapper.java` 신규 추가: `@EgovMapper("QnaManageDAO")` 어노테이션 적용, 기존 DAO와 동일한 메서드 시그니처 정의
- `EgovQnaManageServiceImpl.java`: `qnaManageMapper` 필드 추가 (XML namespace `QnaManageDAO` 공유, SQL 변경 없음)

## 영향 범위

- XML 매퍼 파일(namespace: `QnaManageDAO`) 변경 없음
- 기존 `QnaManageDAO` 빈 동작 유지

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 의존성 추가 불필요 (egovframe-rte-psl-dataaccess 기존 포함)
