### PR TITLE
[refactor][portal] uat/uia LoginDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
@@ -24,6 +24,7 @@ import jakarta.annotation.Resource;
  *  -------    --------    ---------------------------
  *  2009.03.06  박지욱          최초 생성
  *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *  2025.05.28  dasomel        LoginDAO(EgovAbstractMapper) → LoginMapper(@EgovMapper) 방식으로 전환
  *
  *  </pre>
  */
@@ -31,7 +32,7 @@ import jakarta.annotation.Resource;
 public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements EgovLoginService {
 
 	@Resource(name = "loginDAO")
-	private LoginDAO loginDAO;
+	private LoginMapper loginDAO;
 
 	/**
 	 * 일반 로그인을 처리한다

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
@@ -1,0 +1,58 @@
+package egovframework.let.uat.uia.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.LoginVO;
+
+/**
+ * 일반 로그인을 처리하는 MyBatis Mapper 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.06
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.06  박지욱          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *  2025.05.28  dasomel        EgovAbstractMapper → @EgovMapper 어노테이션 방식으로 전환
+ *
+ *  </pre>
+ */
+@EgovMapper("loginDAO")
+public interface LoginMapper {
+
+	/**
+	 * 일반 로그인을 처리한다
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO actionLogin(LoginVO vo) throws Exception;
+
+	/**
+	 * 아이디를 찾는다.
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO searchId(LoginVO vo) throws Exception;
+
+	/**
+	 * 비밀번호를 찾는다.
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO searchPassword(LoginVO vo) throws Exception;
+
+	/**
+	 * 변경된 비밀번호를 저장한다.
+	 * @param vo LoginVO
+	 * @exception Exception
+	 */
+	void updatePassword(LoginVO vo) throws Exception;
+}

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 스캔 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
portal-site-template의 `uat/uia` 로그인 모듈에 `@EgovMapper` 인터페이스 매핑 방식을 적용한다. 기존 #49(sec/gmt), #51(sec/rgm), #52(sec/rmt), #53(uss/sam/ipm), #54(uss/ion/bnr), #58(uss/olh/faq), #63(uss/olh/qna) 동일 패턴.

## 변경 내용
- 신규 `LoginMapper` 인터페이스(@EgovMapper) 추가
- `EgovLoginServiceImpl`: 의존성 타입을 `LoginDAO` → `LoginMapper`로 변경 (`@Resource(name="loginDAO")` 그대로 유지)
- 5개 RDBMS XML namespace를 인터페이스 FQN으로 변경 (altibase/cubrid/mysql/oracle/tibero)
- `context-mapper.xml`에 `MapperConfigurer` 빈 추가
- SQL 무변경

## 영향 범위
- 외부 API 변경 없음
- 타입 안전성 향상

## 체크리스트
- [x] 단일 모듈(uat/uia) 다룸
- [x] mvn compile 통과
- [x] 기존 @EgovMapper PR과 동일 패턴
