### PR TITLE
[refactor][5.0.x][portal] uss/olh/qna 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.42</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageDefaultVO.java
@@ -2,10 +2,13 @@ package egovframework.let.uss.olh.qna.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * 
+ *
  * Q&A를 처리하는 DefaultVO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -14,16 +17,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QnaManageDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -31,19 +36,19 @@ public class QnaManageDefaultVO implements Serializable {
 
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -57,156 +62,12 @@ public class QnaManageDefaultVO implements Serializable {
     private int recordCountPerPage = 10;
 
 	/**
-	 * searchCondition attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @return searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @return searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @return searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @return pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @return pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @return pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @return firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @return lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 를 리턴한다.
-	 * @return the int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @return recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
-	/**
      * toString 메소드를 대치한다.
      */
     public String toString() {
     	return ToStringBuilder.reflectionToString(this);
     }
-    
-    
-    
+
+
+
 }

--- a/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageVO.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/QnaManageVO.java
@@ -3,8 +3,11 @@ package egovframework.let.uss.olh.qna.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
- * 
+ *
  * Q&A를 처리하는 VO 클래스
  * @author 공통서비스 개발팀 박정규
  * @since 2009.04.01
@@ -13,31 +16,33 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.01  박정규          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class QnaManageVO extends QnaManageDefaultVO {
-	
+
     private static final long serialVersionUID = 1L;
-    
+
     /** QA ID */
     private String qaId;
-    
+
     /** 질문제목 */
     @EgovNullCheck
     @Size(max=250)
-    private String qestnSj;    
-    
+    private String qestnSj;
+
     /** 질문내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String qestnCn;
-    
+
     /** 작성비밀번호 */
     @EgovNullCheck
     @Size(max=20)
@@ -46,18 +51,18 @@ public class QnaManageVO extends QnaManageDefaultVO {
     /** 지역번호 */
     @Size(max=4)
     private String areaNo;
-    
-    /** 중간전화번호 */     
+
+    /** 중간전화번호 */
     @Size(max=4)
     private String middleTelno;
-    
+
     /** 끝전화번호 */
     @Size(max=4)
     private String endTelno;
-        
+
     /** 이메일 주소 */
     private String emailAdres;
-        
+
     /** 이메일 답변여부 */
     private String emailAnswerAt;
 
@@ -65,42 +70,42 @@ public class QnaManageVO extends QnaManageDefaultVO {
     @EgovNullCheck
     @Size(max=4)
     private String wrterNm;
-    
+
     /** 작성일자 */
     private String writngDe;
-    
+
     /** 조회횟수 */
     private String inqireCo;
-        
+
     /** 질의응답처리상태코드 */
     private String qnaProcessSttusCode;
 
     /** 질의응답처리상태코드명 */
     private String qnaProcessSttusCodeNm;
-    
+
     /** 답변내용 */
     @EgovNullCheck
     @Size(max=2500)
     private String answerCn;
-    
+
     /** 답변일자 */
     private String answerDe;
 
     /** 작성비밀번호 확인여부 */
     private String passwordConfirmAt;
-    
+
     /** 답변자명 */
     private String emplyrNm;
-    
+
     /** 사무실전화번호 */
     private String offmTelno;
 
     /** 답변자 EMAIL 주소 */
     private String aemailAdres;
-    
+
     /** 부서명 */
     private String orgnztNm;
-        
+
     /** 최초등록시점 */
     private String frstRegisterPnttm;
 
@@ -113,406 +118,4 @@ public class QnaManageVO extends QnaManageDefaultVO {
     /** 최종수정자ID */
     private String lastUpdusrId;
 
-	/**
-	 * qaId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQaId() {
-		return qaId;
-	}
-
-	/**
-	 * qaId attribute 값을 설정한다.
-	 * @return qaId String
-	 */
-	public void setQaId(String qaId) {
-		this.qaId = qaId;
-	}
-
-	/**
-	 * qestnSj attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnSj() {
-		return qestnSj;
-	}
-
-	/**
-	 * qestnSj attribute 값을 설정한다.
-	 * @return qestnSj String
-	 */
-	public void setQestnSj(String qestnSj) {
-		this.qestnSj = qestnSj;
-	}
-
-	/**
-	 * qestnCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQestnCn() {
-		return qestnCn;
-	}
-
-	/**
-	 * qestnCn attribute 값을 설정한다.
-	 * @return qestnCn String
-	 */
-	public void setQestnCn(String qestnCn) {
-		this.qestnCn = qestnCn;
-	}
-
-	/**
-	 * writngPassword attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWritngPassword() {
-		return writngPassword;
-	}
-
-	/**
-	 * writngPassword attribute 값을 설정한다.
-	 * @return writngPassword String
-	 */
-	public void setWritngPassword(String writngPassword) {
-		this.writngPassword = writngPassword;
-	}
-
-	/**
-	 * areaNo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @return areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-
-	/**
-	 * middleTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getMiddleTelno() {
-		return middleTelno;
-	}
-
-	/**
-	 * middleTelno attribute 값을 설정한다.
-	 * @return middleTelno String
-	 */
-	public void setMiddleTelno(String middleTelno) {
-		this.middleTelno = middleTelno;
-	}
-
-	/**
-	 * endTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEndTelno() {
-		return endTelno;
-	}
-
-	/**
-	 * endTelno attribute 값을 설정한다.
-	 * @return endTelno String
-	 */
-	public void setEndTelno(String endTelno) {
-		this.endTelno = endTelno;
-	}
-
-	/**
-	 * emailAdres attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmailAdres() {
-		return emailAdres;
-	}
-
-	/**
-	 * emailAdres attribute 값을 설정한다.
-	 * @return emailAdres String
-	 */
-	public void setEmailAdres(String emailAdres) {
-		this.emailAdres = emailAdres;
-	}
-
-	/**
-	 * emailAnswerAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmailAnswerAt() {
-		return emailAnswerAt;
-	}
-
-	/**
-	 * emailAnswerAt attribute 값을 설정한다.
-	 * @return emailAnswerAt String
-	 */
-	public void setEmailAnswerAt(String emailAnswerAt) {
-		this.emailAnswerAt = emailAnswerAt;
-	}
-
-	/**
-	 * wrterNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWrterNm() {
-		return wrterNm;
-	}
-
-	/**
-	 * wrterNm attribute 값을 설정한다.
-	 * @return wrterNm String
-	 */
-	public void setWrterNm(String wrterNm) {
-		this.wrterNm = wrterNm;
-	}
-
-	/**
-	 * writngDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getWritngDe() {
-		return writngDe;
-	}
-
-	/**
-	 * writngDe attribute 값을 설정한다.
-	 * @return writngDe String
-	 */
-	public void setWritngDe(String writngDe) {
-		this.writngDe = writngDe;
-	}
-
-	/**
-	 * inqireCo attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getInqireCo() {
-		return inqireCo;
-	}
-
-	/**
-	 * inqireCo attribute 값을 설정한다.
-	 * @return inqireCo String
-	 */
-	public void setInqireCo(String inqireCo) {
-		this.inqireCo = inqireCo;
-	}
-
-	/**
-	 * qnaProcessSttusCode attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQnaProcessSttusCode() {
-		return qnaProcessSttusCode;
-	}
-
-	/**
-	 * qnaProcessSttusCode attribute 값을 설정한다.
-	 * @return qnaProcessSttusCode String
-	 */
-	public void setQnaProcessSttusCode(String qnaProcessSttusCode) {
-		this.qnaProcessSttusCode = qnaProcessSttusCode;
-	}
-
-	/**
-	 * qnaProcessSttusCodeNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getQnaProcessSttusCodeNm() {
-		return qnaProcessSttusCodeNm;
-	}
-
-	/**
-	 * qnaProcessSttusCodeNm attribute 값을 설정한다.
-	 * @return qnaProcessSttusCodeNm String
-	 */
-	public void setQnaProcessSttusCodeNm(String qnaProcessSttusCodeNm) {
-		this.qnaProcessSttusCodeNm = qnaProcessSttusCodeNm;
-	}
-
-	/**
-	 * answerCn attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerCn() {
-		return answerCn;
-	}
-
-	/**
-	 * answerCn attribute 값을 설정한다.
-	 * @return answerCn String
-	 */
-	public void setAnswerCn(String answerCn) {
-		this.answerCn = answerCn;
-	}
-
-	/**
-	 * answerDe attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAnswerDe() {
-		return answerDe;
-	}
-
-	/**
-	 * answerDe attribute 값을 설정한다.
-	 * @return answerDe String
-	 */
-	public void setAnswerDe(String answerDe) {
-		this.answerDe = answerDe;
-	}
-
-	/**
-	 * passwordConfirmAt attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getPasswordConfirmAt() {
-		return passwordConfirmAt;
-	}
-
-	/**
-	 * passwordConfirmAt attribute 값을 설정한다.
-	 * @return passwordConfirmAt String
-	 */
-	public void setPasswordConfirmAt(String passwordConfirmAt) {
-		this.passwordConfirmAt = passwordConfirmAt;
-	}
-
-	/**
-	 * emplyrNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getEmplyrNm() {
-		return emplyrNm;
-	}
-
-	/**
-	 * emplyrNm attribute 값을 설정한다.
-	 * @return emplyrNm String
-	 */
-	public void setEmplyrNm(String emplyrNm) {
-		this.emplyrNm = emplyrNm;
-	}
-
-	/**
-	 * offmTelno attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOffmTelno() {
-		return offmTelno;
-	}
-
-	/**
-	 * offmTelno attribute 값을 설정한다.
-	 * @return offmTelno String
-	 */
-	public void setOffmTelno(String offmTelno) {
-		this.offmTelno = offmTelno;
-	}
-
-	/**
-	 * aemailAdres attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getAemailAdres() {
-		return aemailAdres;
-	}
-
-	/**
-	 * aemailAdres attribute 값을 설정한다.
-	 * @return aemailAdres String
-	 */
-	public void setAemailAdres(String aemailAdres) {
-		this.aemailAdres = aemailAdres;
-	}
-
-	/**
-	 * orgnztNm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-
-	/**
-	 * orgnztNm attribute 값을 설정한다.
-	 * @return orgnztNm String
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterPnttm() {
-		return frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterPnttm attribute 값을 설정한다.
-	 * @return frstRegisterPnttm String
-	 */
-	public void setFrstRegisterPnttm(String frstRegisterPnttm) {
-		this.frstRegisterPnttm = frstRegisterPnttm;
-	}
-
-	/**
-	 * frstRegisterId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getFrstRegisterId() {
-		return frstRegisterId;
-	}
-
-	/**
-	 * frstRegisterId attribute 값을 설정한다.
-	 * @return frstRegisterId String
-	 */
-	public void setFrstRegisterId(String frstRegisterId) {
-		this.frstRegisterId = frstRegisterId;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrPnttm() {
-		return lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrPnttm attribute 값을 설정한다.
-	 * @return lastUpdusrPnttm String
-	 */
-	public void setLastUpdusrPnttm(String lastUpdusrPnttm) {
-		this.lastUpdusrPnttm = lastUpdusrPnttm;
-	}
-
-	/**
-	 * lastUpdusrId attribute 를 리턴한다.
-	 * @return the String
-	 */
-	public String getLastUpdusrId() {
-		return lastUpdusrId;
-	}
-
-	/**
-	 * lastUpdusrId attribute 값을 설정한다.
-	 * @return lastUpdusrId String
-	 */
-	public void setLastUpdusrId(String lastUpdusrId) {
-		this.lastUpdusrId = lastUpdusrId;
-	}
-
-    
-   
 }


### PR DESCRIPTION
uss/olh/qna 모듈의 QnaManageDefaultVO, QnaManageVO 두 클래스에서 수동으로 작성된 getter/setter 메서드를 모두 제거하고 Lombok `@Getter`/`@Setter` 어노테이션으로 대체했습니다.

pom.xml의 `maven-compiler-plugin`에 `annotationProcessorPaths`를 추가하여 Lombok 어노테이션 프로세서가 컴파일 시 정상 동작하도록 설정했습니다 (5.0.x 브랜치에 누락된 설정).

변경 파일:
- `pom.xml` — maven-compiler-plugin annotationProcessorPaths 추가
- `QnaManageDefaultVO.java` — @Getter/@Setter 적용, 수동 getter/setter 제거
- `QnaManageVO.java` — @Getter/@Setter 적용, 수동 getter/setter 제거

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] mvn compile 통과 확인
