### PR TITLE
[refactor][공통컴포넌트] sec 권한관리 5개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageDAO.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sec.gmt.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sec.gmt.service.GroupManage;
 import egovframework.let.sec.gmt.service.GroupManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 그룹관리에 대한 DAO 클래스를 정의한다.
@@ -27,7 +27,10 @@ import egovframework.let.sec.gmt.service.GroupManageVO;
  */
 
 @Repository("groupManageDAO")
-public class GroupManageDAO extends EgovAbstractMapper {
+public class GroupManageDAO {
+
+	@Resource
+	private GroupManageMapper groupManageMapper;
 
 	/**
 	 * 검색조건에 따른 그룹정보를 조회
@@ -36,17 +39,17 @@ public class GroupManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception {
-		return (GroupManageVO) selectOne("groupManageDAO.selectGroup", groupManageVO);
+		return groupManageMapper.selectGroup(groupManageVO);
 	}
 
 	/**
 	 * 시스템사용 목적별 그룹 목록 조회
 	 * @param groupManageVO GroupManageVO
-	 * @return GroupManageVO
+	 * @return List<GroupManageVO>
 	 * @exception Exception
 	 */
 	public List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception {
-		return selectList("groupManageDAO.selectGroupList", groupManageVO);
+		return groupManageMapper.selectGroupList(groupManageVO);
 	}
 
 	/**
@@ -55,7 +58,7 @@ public class GroupManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void insertGroup(GroupManage groupManage) throws Exception {
-		insert("groupManageDAO.insertGroup", groupManage);
+		groupManageMapper.insertGroup(groupManage);
 	}
 
 	/**
@@ -64,7 +67,7 @@ public class GroupManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void updateGroup(GroupManage groupManage) throws Exception {
-		update("groupManageDAO.updateGroup", groupManage);
+		groupManageMapper.updateGroup(groupManage);
 	}
 
 	/**
@@ -73,16 +76,17 @@ public class GroupManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void deleteGroup(GroupManage groupManage) throws Exception {
-		delete("groupManageDAO.deleteGroup", groupManage);
+		groupManageMapper.deleteGroup(groupManage);
 	}
 
-    /**
-	 * 롤목록 총 갯수를 조회한다.
+	/**
+	 * 그룹목록 총 갯수를 조회한다.
 	 * @param groupManageVO GroupManageVO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception {
-        return (Integer)selectOne("groupManageDAO.selectGroupListTotCnt", groupManageVO);
-    }
+	public int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception {
+		return groupManageMapper.selectGroupListTotCnt(groupManageVO);
+	}
+
 }

--- a/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
@@ -1,0 +1,75 @@
+package egovframework.let.sec.gmt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sec.gmt.service.GroupManage;
+import egovframework.let.sec.gmt.service.GroupManageVO;
+
+/**
+ * 그룹관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이문준
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이문준          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface GroupManageMapper {
+
+    /**
+     * 검색조건에 따른 그룹정보를 조회
+     * @param groupManageVO GroupManageVO
+     * @return GroupManageVO
+     * @exception Exception
+     */
+    GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception;
+
+    /**
+     * 시스템사용 목적별 그룹 목록 조회
+     * @param groupManageVO GroupManageVO
+     * @return List<GroupManageVO>
+     * @exception Exception
+     */
+    List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception;
+
+    /**
+     * 그룹 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
+     * @param groupManage GroupManage
+     * @exception Exception
+     */
+    void insertGroup(GroupManage groupManage) throws Exception;
+
+    /**
+     * 화면에 조회된 그룹의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
+     * @param groupManage GroupManage
+     * @exception Exception
+     */
+    void updateGroup(GroupManage groupManage) throws Exception;
+
+    /**
+     * 불필요한 그룹정보를 화면에 조회하여 데이터베이스에서 삭제
+     * @param groupManage GroupManage
+     * @exception Exception
+     */
+    void deleteGroup(GroupManage groupManage) throws Exception;
+
+    /**
+     * 그룹목록 총 갯수를 조회한다.
+     * @param groupManageVO GroupManageVO
+     * @return int
+     * @exception Exception
+     */
+    int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sec/ram/service/impl/AuthorManageDAO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/impl/AuthorManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sec.ram.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sec.ram.service.AuthorManage;
 import egovframework.let.sec.ram.service.AuthorManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 권한관리에 대한 DAO 클래스를 정의한다.
@@ -27,72 +27,76 @@ import egovframework.let.sec.ram.service.AuthorManageVO;
  */
 
 @Repository("authorManageDAO")
-public class AuthorManageDAO extends EgovAbstractMapper {
+public class AuthorManageDAO {
 
-    /**
+	@Resource
+	private AuthorManageMapper authorManageMapper;
+
+	/**
 	 * 권한목록을 조회한다.
 	 * @param authorManageVO AuthorManageVO
 	 * @return List<AuthorManageVO>
 	 * @exception Exception
 	 */
 	public List<AuthorManageVO> selectAuthorList(AuthorManageVO authorManageVO) throws Exception {
-        return selectList("authorManageDAO.selectAuthorList", authorManageVO);
-    }
+		return authorManageMapper.selectAuthorList(authorManageVO);
+	}
 
 	/**
 	 * 권한을 등록한다.
 	 * @param authorManage AuthorManage
 	 * @exception Exception
 	 */
-    public void insertAuthor(AuthorManage authorManage) throws Exception {
-        insert("authorManageDAO.insertAuthor", authorManage);
-    }
+	public void insertAuthor(AuthorManage authorManage) throws Exception {
+		authorManageMapper.insertAuthor(authorManage);
+	}
 
-    /**
+	/**
 	 * 권한을 수정한다.
 	 * @param authorManage AuthorManage
 	 * @exception Exception
 	 */
-    public void updateAuthor(AuthorManage authorManage) throws Exception {
-        update("authorManageDAO.updateAuthor", authorManage);
-    }
+	public void updateAuthor(AuthorManage authorManage) throws Exception {
+		authorManageMapper.updateAuthor(authorManage);
+	}
 
-    /**
+	/**
 	 * 권한을 삭제한다.
 	 * @param authorManage AuthorManage
 	 * @exception Exception
 	 */
-    public void deleteAuthor(AuthorManage authorManage) throws Exception {
-        delete("authorManageDAO.deleteAuthor", authorManage);
-    }
+	public void deleteAuthor(AuthorManage authorManage) throws Exception {
+		authorManageMapper.deleteAuthor(authorManage);
+	}
 
-    /**
+	/**
 	 * 권한을 조회한다.
 	 * @param authorManageVO AuthorManageVO
 	 * @return AuthorManageVO
 	 * @exception Exception
 	 */
-    public AuthorManageVO selectAuthor(AuthorManageVO authorManageVO) throws Exception {
-        return (AuthorManageVO) selectOne("authorManageDAO.selectAuthor", authorManageVO);
-    }
+	public AuthorManageVO selectAuthor(AuthorManageVO authorManageVO) throws Exception {
+		return authorManageMapper.selectAuthor(authorManageVO);
+	}
 
-    /**
+	/**
 	 * 권한목록 총 갯수를 조회한다.
 	 * @param authorManageVO AuthorManageVO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectAuthorListTotCnt(AuthorManageVO authorManageVO)  throws Exception {
-        return (Integer)selectOne("authorManageDAO.selectAuthorListTotCnt", authorManageVO);
-    }
+	public int selectAuthorListTotCnt(AuthorManageVO authorManageVO) throws Exception {
+		return authorManageMapper.selectAuthorListTotCnt(authorManageVO);
+	}
 
-    /**
+	/**
 	 * 모든 권한목록을 조회한다.
 	 * @param authorManageVO AuthorManageVO
 	 * @return List<AuthorManageVO>
 	 * @exception Exception
 	 */
 	public List<AuthorManageVO> selectAuthorAllList(AuthorManageVO authorManageVO) throws Exception {
-        return selectList("authorManageDAO.selectAuthorAllList", authorManageVO);
-    }
+		return authorManageMapper.selectAuthorAllList(authorManageVO);
+	}
+
 }

--- a/src/main/java/egovframework/let/sec/ram/service/impl/AuthorManageMapper.java
+++ b/src/main/java/egovframework/let/sec/ram/service/impl/AuthorManageMapper.java
@@ -1,0 +1,83 @@
+package egovframework.let.sec.ram.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sec.ram.service.AuthorManage;
+import egovframework.let.sec.ram.service.AuthorManageVO;
+
+/**
+ * 권한관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이문준
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이문준          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface AuthorManageMapper {
+
+    /**
+     * 권한목록을 조회한다.
+     * @param authorManageVO AuthorManageVO
+     * @return List<AuthorManageVO>
+     * @exception Exception
+     */
+    List<AuthorManageVO> selectAuthorList(AuthorManageVO authorManageVO) throws Exception;
+
+    /**
+     * 권한을 등록한다.
+     * @param authorManage AuthorManage
+     * @exception Exception
+     */
+    void insertAuthor(AuthorManage authorManage) throws Exception;
+
+    /**
+     * 권한을 수정한다.
+     * @param authorManage AuthorManage
+     * @exception Exception
+     */
+    void updateAuthor(AuthorManage authorManage) throws Exception;
+
+    /**
+     * 권한을 삭제한다.
+     * @param authorManage AuthorManage
+     * @exception Exception
+     */
+    void deleteAuthor(AuthorManage authorManage) throws Exception;
+
+    /**
+     * 권한을 조회한다.
+     * @param authorManageVO AuthorManageVO
+     * @return AuthorManageVO
+     * @exception Exception
+     */
+    AuthorManageVO selectAuthor(AuthorManageVO authorManageVO) throws Exception;
+
+    /**
+     * 권한목록 총 갯수를 조회한다.
+     * @param authorManageVO AuthorManageVO
+     * @return int
+     * @exception Exception
+     */
+    int selectAuthorListTotCnt(AuthorManageVO authorManageVO) throws Exception;
+
+    /**
+     * 모든 권한목록을 조회한다.
+     * @param authorManageVO AuthorManageVO
+     * @return List<AuthorManageVO>
+     * @exception Exception
+     */
+    List<AuthorManageVO> selectAuthorAllList(AuthorManageVO authorManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sec/ram/service/impl/AuthorRoleManageDAO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/impl/AuthorRoleManageDAO.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import egovframework.let.sec.ram.service.AuthorRoleManage;
 import egovframework.let.sec.ram.service.AuthorRoleManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 권한별 롤관리에 대한 DAO 클래스를 정의한다.
@@ -29,6 +30,9 @@ import egovframework.let.sec.ram.service.AuthorRoleManageVO;
 @Repository("authorRoleManageDAO")
 public class AuthorRoleManageDAO extends EgovAbstractMapper {
 
+	@Resource
+	private AuthorRoleManageMapper authorRoleManageMapper;
+
 	/**
 	 * 권한 롤 관계정보를 조회
 	 * @param authorRoleManageVO AuthorRoleManageVO
@@ -46,7 +50,7 @@ public class AuthorRoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<AuthorRoleManageVO> selectAuthorRoleList(AuthorRoleManageVO authorRoleManageVO) throws Exception {
-		return selectList("authorRoleManageDAO.selectAuthorRoleList", authorRoleManageVO);
+		return authorRoleManageMapper.selectAuthorRoleList(authorRoleManageVO);
 	}
 
 	/**
@@ -55,7 +59,7 @@ public class AuthorRoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void insertAuthorRole(AuthorRoleManage authorRoleManage) throws Exception {
-		insert("authorRoleManageDAO.insertAuthorRole", authorRoleManage);
+		authorRoleManageMapper.insertAuthorRole(authorRoleManage);
 	}
 
 	/**
@@ -73,17 +77,17 @@ public class AuthorRoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void deleteAuthorRole(AuthorRoleManage authorRoleManage) throws Exception {
-		delete("authorRoleManageDAO.deleteAuthorRole", authorRoleManage);
+		authorRoleManageMapper.deleteAuthorRole(authorRoleManage);
 	}
 
-    /**
+	/**
 	 * 목록조회 카운트를 반환한다
 	 * @param authorRoleManageVO AuthorRoleManageVO
 	 * @return int
 	 * @exception Exception
 	 */
 	public int selectAuthorRoleListTotCnt(AuthorRoleManageVO authorRoleManageVO) throws Exception {
-		return (Integer)selectOne("authorRoleManageDAO.selectAuthorRoleListTotCnt", authorRoleManageVO);
+		return authorRoleManageMapper.selectAuthorRoleListTotCnt(authorRoleManageVO);
 	}
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/impl/AuthorRoleManageMapper.java
+++ b/src/main/java/egovframework/let/sec/ram/service/impl/AuthorRoleManageMapper.java
@@ -1,0 +1,60 @@
+package egovframework.let.sec.ram.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sec.ram.service.AuthorRoleManage;
+import egovframework.let.sec.ram.service.AuthorRoleManageVO;
+
+/**
+ * 권한별 롤관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이문준
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이문준          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface AuthorRoleManageMapper {
+
+    /**
+     * 권한 롤 관계정보 목록 조회
+     * @param authorRoleManageVO AuthorRoleManageVO
+     * @return List<AuthorRoleManageVO>
+     * @exception Exception
+     */
+    List<AuthorRoleManageVO> selectAuthorRoleList(AuthorRoleManageVO authorRoleManageVO) throws Exception;
+
+    /**
+     * 목록조회 카운트를 반환한다
+     * @param authorRoleManageVO AuthorRoleManageVO
+     * @return int
+     * @exception Exception
+     */
+    int selectAuthorRoleListTotCnt(AuthorRoleManageVO authorRoleManageVO) throws Exception;
+
+    /**
+     * 권한 롤 관계정보를 화면에서 입력하여 입력항목의 정합성을 체크하고 데이터베이스에 저장
+     * @param authorRoleManage AuthorRoleManage
+     * @exception Exception
+     */
+    void insertAuthorRole(AuthorRoleManage authorRoleManage) throws Exception;
+
+    /**
+     * 권한 롤 관계정보를 화면에 조회하여 데이터베이스에서 삭제
+     * @param authorRoleManage AuthorRoleManage
+     * @exception Exception
+     */
+    void deleteAuthorRole(AuthorRoleManage authorRoleManage) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupDAO.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sec.rgm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sec.rgm.service.AuthorGroup;
 import egovframework.let.sec.rgm.service.AuthorGroupVO;
+import jakarta.annotation.Resource;
 
 /**
  * 권한그룹에 대한 DAO 클래스를 정의한다.
@@ -27,7 +27,10 @@ import egovframework.let.sec.rgm.service.AuthorGroupVO;
  */
 
 @Repository("authorGroupDAO")
-public class AuthorGroupDAO extends EgovAbstractMapper {
+public class AuthorGroupDAO {
+
+	@Resource
+	private AuthorGroupMapper authorGroupMapper;
 
 	/**
 	 * 그룹별 할당된 권한 목록 조회
@@ -36,7 +39,7 @@ public class AuthorGroupDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception {
-		return selectList("authorGroupDAO.selectAuthorGroupList", authorGroupVO);
+		return authorGroupMapper.selectAuthorGroupList(authorGroupVO);
 	}
 
 	/**
@@ -45,7 +48,7 @@ public class AuthorGroupDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void insertAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		insert("authorGroupDAO.insertAuthorGroup", authorGroup);
+		authorGroupMapper.insertAuthorGroup(authorGroup);
 	}
 
 	/**
@@ -54,7 +57,7 @@ public class AuthorGroupDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void updateAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		update("authorGroupDAO.updateAuthorGroup", authorGroup);
+		authorGroupMapper.updateAuthorGroup(authorGroup);
 	}
 
 	/**
@@ -63,16 +66,17 @@ public class AuthorGroupDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		delete("authorGroupDAO.deleteAuthorGroup", authorGroup);
+		authorGroupMapper.deleteAuthorGroup(authorGroup);
 	}
 
-    /**
+	/**
 	 * 그룹권한목록 총 갯수를 조회한다.
 	 * @param authorGroupVO AuthorGroupVO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception {
-        return (Integer)selectOne("authorGroupDAO.selectAuthorGroupListTotCnt", authorGroupVO);
-    }
+	public int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception {
+		return authorGroupMapper.selectAuthorGroupListTotCnt(authorGroupVO);
+	}
+
 }

--- a/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
@@ -1,0 +1,67 @@
+package egovframework.let.sec.rgm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sec.rgm.service.AuthorGroup;
+import egovframework.let.sec.rgm.service.AuthorGroupVO;
+
+/**
+ * 권한그룹에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이문준
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  이문준          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface AuthorGroupMapper {
+
+    /**
+     * 그룹별 할당된 권한 목록 조회
+     * @param authorGroupVO AuthorGroupVO
+     * @return List<AuthorGroupVO>
+     * @exception Exception
+     */
+    List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception;
+
+    /**
+     * 그룹에 권한정보를 할당하여 데이터베이스에 등록
+     * @param authorGroup AuthorGroup
+     * @exception Exception
+     */
+    void insertAuthorGroup(AuthorGroup authorGroup) throws Exception;
+
+    /**
+     * 화면에 조회된 그룹권한정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
+     * @param authorGroup AuthorGroup
+     * @exception Exception
+     */
+    void updateAuthorGroup(AuthorGroup authorGroup) throws Exception;
+
+    /**
+     * 그룹별 할당된 시스템 메뉴 접근권한을 삭제
+     * @param authorGroup AuthorGroup
+     * @exception Exception
+     */
+    void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception;
+
+    /**
+     * 그룹권한목록 총 갯수를 조회한다.
+     * @param authorGroupVO AuthorGroupVO
+     * @return int
+     * @exception Exception
+     */
+    int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageDAO.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sec.rmt.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sec.rmt.service.RoleManage;
 import egovframework.let.sec.rmt.service.RoleManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 롤관리에 대한 DAO 클래스를 정의한다.
@@ -27,7 +27,10 @@ import egovframework.let.sec.rmt.service.RoleManageVO;
  */
 
 @Repository("roleManageDAO")
-public class RoleManageDAO extends EgovAbstractMapper {
+public class RoleManageDAO {
+
+	@Resource
+	private RoleManageMapper roleManageMapper;
 
 	/**
 	 * 등록된 롤 정보 조회
@@ -36,7 +39,7 @@ public class RoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public RoleManageVO selectRole(RoleManageVO roleManageVO) throws Exception {
-		return (RoleManageVO) selectOne("roleManageDAO.selectRole", roleManageVO);
+		return roleManageMapper.selectRole(roleManageVO);
 	}
 
 	/**
@@ -46,7 +49,7 @@ public class RoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO) throws Exception {
-		return selectList("roleManageDAO.selectRoleList", roleManageVO);
+		return roleManageMapper.selectRoleList(roleManageVO);
 	}
 
 	/**
@@ -55,34 +58,36 @@ public class RoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void insertRole(RoleManage roleManage) throws Exception {
-		insert("roleManageDAO.insertRole", roleManage);
+		roleManageMapper.insertRole(roleManage);
 	}
+
 	/**
 	 * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 수정
 	 * @param roleManage RoleManage
 	 * @exception Exception
 	 */
 	public void updateRole(RoleManage roleManage) throws Exception {
-		update("roleManageDAO.updateRole", roleManage);
+		roleManageMapper.updateRole(roleManage);
 	}
+
 	/**
 	 * 불필요한 롤정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param roleManage RoleManage
 	 * @exception Exception
 	 */
 	public void deleteRole(RoleManage roleManage) throws Exception {
-		delete("roleManageDAO.deleteRole", roleManage);
+		roleManageMapper.deleteRole(roleManage);
 	}
 
-    /**
+	/**
 	 * 롤목록 총 갯수를 조회한다.
 	 * @param roleManageVO RoleManageVO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectRoleListTotCnt(RoleManageVO roleManageVO) throws Exception {
-        return (Integer)selectOne("roleManageDAO.selectAuthorListTotCnt", roleManageVO);
-    }
+	public int selectRoleListTotCnt(RoleManageVO roleManageVO) throws Exception {
+		return roleManageMapper.selectAuthorListTotCnt(roleManageVO);
+	}
 
 	/**
 	 * 등록된 모든 롤 정보 목록 조회
@@ -91,7 +96,7 @@ public class RoleManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO) throws Exception {
-		return selectList("roleManageDAO.selectRoleAllList", roleManageVO);
+		return roleManageMapper.selectRoleAllList(roleManageVO);
 	}
 
 }

--- a/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageMapper.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageMapper.java
@@ -1,0 +1,83 @@
+package egovframework.let.sec.rmt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sec.rmt.service.RoleManage;
+import egovframework.let.sec.rmt.service.RoleManageVO;
+
+/**
+ * 롤관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이문준
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이문준          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface RoleManageMapper {
+
+    /**
+     * 등록된 롤 정보 조회
+     * @param roleManageVO RoleManageVO
+     * @return RoleManageVO
+     * @exception Exception
+     */
+    RoleManageVO selectRole(RoleManageVO roleManageVO) throws Exception;
+
+    /**
+     * 등록된 롤 정보 목록 조회
+     * @param roleManageVO RoleManageVO
+     * @return List<RoleManageVO>
+     * @exception Exception
+     */
+    List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO) throws Exception;
+
+    /**
+     * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 등록
+     * @param roleManage RoleManage
+     * @exception Exception
+     */
+    void insertRole(RoleManage roleManage) throws Exception;
+
+    /**
+     * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 수정
+     * @param roleManage RoleManage
+     * @exception Exception
+     */
+    void updateRole(RoleManage roleManage) throws Exception;
+
+    /**
+     * 불필요한 롤정보를 화면에 조회하여 데이터베이스에서 삭제
+     * @param roleManage RoleManage
+     * @exception Exception
+     */
+    void deleteRole(RoleManage roleManage) throws Exception;
+
+    /**
+     * 롤목록 총 갯수를 조회한다.
+     * @param roleManageVO RoleManageVO
+     * @return int
+     * @exception Exception
+     */
+    int selectAuthorListTotCnt(RoleManageVO roleManageVO) throws Exception;
+
+    /**
+     * 등록된 모든 롤 정보 목록 조회
+     * @param roleManageVO RoleManageVO
+     * @return List<RoleManageVO>
+     * @exception Exception
+     */
+    List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
 	<resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorManageMapper">
 
 
     <resultMap id="author" type="egovframework.let.sec.ram.service.AuthorManageVO">
@@ -11,7 +11,7 @@
         <result property="authorCreatDe" column="AUTHOR_CREAT_DE"/>
     </resultMap>
 
-    <select id="authorManageDAO.selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
         
             SELECT  * 
               FROM  (
@@ -36,7 +36,7 @@
                          
     </select>
 
-    <insert id="authorManageDAO.insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <insert id="insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             INSERT INTO LETTNAUTHORINFO 
                   ( AUTHOR_CODE
@@ -50,7 +50,7 @@
           
     </insert>
 
-    <update id="authorManageDAO.updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <update id="updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             UPDATE LETTNAUTHORINFO 
                SET AUTHOR_NM=#{authorNm}
@@ -59,14 +59,14 @@
         
     </update>
     
-    <delete id="authorManageDAO.deleteAuthor">
+    <delete id="deleteAuthor">
         
             DELETE FROM LETTNAUTHORINFO 
              WHERE AUTHOR_CODE=#{authorCode}
         
     </delete>
     
-    <select id="authorManageDAO.selectAuthor" resultMap="author">
+    <select id="selectAuthor" resultMap="author">
         
             SELECT AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO 
@@ -74,7 +74,7 @@
         
     </select>
     
-    <select id="authorManageDAO.selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
+    <select id="selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
             SELECT COUNT(*) totcnt
             FROM LETTNAUTHORINFO
             WHERE 1=1
@@ -83,7 +83,7 @@
             </if>
     </select>
     
-    <select id="authorManageDAO.selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorManageMapper">
 
 
     <resultMap id="author" type="egovframework.let.sec.ram.service.AuthorManageVO">
@@ -11,7 +11,7 @@
         <result property="authorCreatDe" column="AUTHOR_CREAT_DE"/>
     </resultMap>
 
-    <select id="authorManageDAO.selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
         
             SELECT  * 
               FROM  (
@@ -36,7 +36,7 @@
                          
     </select>
 
-    <insert id="authorManageDAO.insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <insert id="insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             INSERT INTO LETTNAUTHORINFO 
                   ( AUTHOR_CODE
@@ -50,7 +50,7 @@
           
     </insert>
 
-    <update id="authorManageDAO.updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <update id="updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             UPDATE LETTNAUTHORINFO 
                SET AUTHOR_NM=#{authorNm}
@@ -59,14 +59,14 @@
         
     </update>
     
-    <delete id="authorManageDAO.deleteAuthor">
+    <delete id="deleteAuthor">
         
             DELETE FROM LETTNAUTHORINFO 
              WHERE AUTHOR_CODE=#{authorCode}
         
     </delete>
     
-    <select id="authorManageDAO.selectAuthor" resultMap="author">
+    <select id="selectAuthor" resultMap="author">
         
             SELECT AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO 
@@ -74,7 +74,7 @@
         
     </select>
     
-    <select id="authorManageDAO.selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
+    <select id="selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
             SELECT COUNT(*) totcnt
             FROM LETTNAUTHORINFO
             WHERE 1=1
@@ -83,7 +83,7 @@
             </if>
     </select>
     
-    <select id="authorManageDAO.selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorManageMapper">
 
 
     <resultMap id="author" type="egovframework.let.sec.ram.service.AuthorManageVO">
@@ -11,7 +11,7 @@
         <result property="authorCreatDe" column="AUTHOR_CREAT_DE"/>
     </resultMap>
 
-    <select id="authorManageDAO.selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO
@@ -23,7 +23,7 @@
             LIMIT #{recordCountPerPage} OFFSET #{firstIndex}      
     </select>
 
-    <insert id="authorManageDAO.insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <insert id="insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             INSERT INTO LETTNAUTHORINFO 
                   ( AUTHOR_CODE
@@ -37,7 +37,7 @@
          
     </insert>
 
-    <update id="authorManageDAO.updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <update id="updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             UPDATE LETTNAUTHORINFO 
                SET AUTHOR_NM=#{authorNm}
@@ -46,14 +46,14 @@
         
     </update>
     
-    <delete id="authorManageDAO.deleteAuthor">
+    <delete id="deleteAuthor">
         
             DELETE FROM LETTNAUTHORINFO 
              WHERE AUTHOR_CODE=#{authorCode}
         
     </delete>
     
-    <select id="authorManageDAO.selectAuthor" resultMap="author">
+    <select id="selectAuthor" resultMap="author">
         
             SELECT AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO 
@@ -61,7 +61,7 @@
         
     </select>
     
-    <select id="authorManageDAO.selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
+    <select id="selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
             SELECT COUNT(*) totcnt
             FROM LETTNAUTHORINFO
             WHERE 1=1
@@ -70,7 +70,7 @@
             </if> 
     </select>
     
-    <select id="authorManageDAO.selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorManageMapper">
 
 
     <resultMap id="author" type="egovframework.let.sec.ram.service.AuthorManageVO">
@@ -11,7 +11,7 @@
         <result property="authorCreatDe" column="AUTHOR_CREAT_DE"/>
     </resultMap>
 
-    <select id="authorManageDAO.selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
         
             SELECT  * 
               FROM  (
@@ -36,7 +36,7 @@
                          
     </select>
 
-    <insert id="authorManageDAO.insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <insert id="insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             INSERT INTO LETTNAUTHORINFO 
                   ( AUTHOR_CODE
@@ -50,7 +50,7 @@
           
     </insert>
 
-    <update id="authorManageDAO.updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <update id="updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             UPDATE LETTNAUTHORINFO 
                SET AUTHOR_NM=#{authorNm}
@@ -59,14 +59,14 @@
         
     </update>
     
-    <delete id="authorManageDAO.deleteAuthor">
+    <delete id="deleteAuthor">
         
             DELETE FROM LETTNAUTHORINFO 
              WHERE AUTHOR_CODE=#{authorCode}
         
     </delete>
     
-    <select id="authorManageDAO.selectAuthor" resultMap="author">
+    <select id="selectAuthor" resultMap="author">
         
             SELECT AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO 
@@ -74,7 +74,7 @@
         
     </select>
     
-    <select id="authorManageDAO.selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
+    <select id="selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
             SELECT COUNT(*) totcnt
             FROM LETTNAUTHORINFO
             WHERE 1=1
@@ -83,7 +83,7 @@
             </if>
     </select>
     
-    <select id="authorManageDAO.selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorManageMapper">
 
 
     <resultMap id="author" type="egovframework.let.sec.ram.service.AuthorManageVO">
@@ -11,7 +11,7 @@
         <result property="authorCreatDe" column="AUTHOR_CREAT_DE"/>
     </resultMap>
 
-    <select id="authorManageDAO.selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
         
             SELECT  * 
               FROM  (
@@ -36,7 +36,7 @@
                          
     </select>
 
-    <insert id="authorManageDAO.insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <insert id="insertAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             INSERT INTO LETTNAUTHORINFO 
                   ( AUTHOR_CODE
@@ -50,7 +50,7 @@
           
     </insert>
 
-    <update id="authorManageDAO.updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
+    <update id="updateAuthor" parameterType="egovframework.let.sec.ram.service.AuthorManage">
         
             UPDATE LETTNAUTHORINFO 
                SET AUTHOR_NM=#{authorNm}
@@ -59,14 +59,14 @@
         
     </update>
     
-    <delete id="authorManageDAO.deleteAuthor">
+    <delete id="deleteAuthor">
         
             DELETE FROM LETTNAUTHORINFO 
              WHERE AUTHOR_CODE=#{authorCode}
         
     </delete>
     
-    <select id="authorManageDAO.selectAuthor" resultMap="author">
+    <select id="selectAuthor" resultMap="author">
         
             SELECT AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO 
@@ -74,7 +74,7 @@
         
     </select>
     
-    <select id="authorManageDAO.selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
+    <select id="selectAuthorListTotCnt" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultType="int">
             SELECT COUNT(*) totcnt
             FROM LETTNAUTHORINFO
             WHERE 1=1
@@ -83,7 +83,7 @@
             </if>
     </select>
     
-    <select id="authorManageDAO.selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
+    <select id="selectAuthorAllList" parameterType="egovframework.let.sec.ram.service.AuthorManageVO" resultMap="author">
             SELECT
                    AUTHOR_CODE, AUTHOR_NM, AUTHOR_DC, AUTHOR_CREAT_DE
               FROM LETTNAUTHORINFO

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorRoleManageMapper">
 
 
     <resultMap id="authorRole" type="egovframework.let.sec.ram.service.AuthorRoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorRoleManageMapper">
 
 
     <resultMap id="authorRole" type="egovframework.let.sec.ram.service.AuthorRoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorRoleManageMapper">
 
 
     <resultMap id="authorRole" type="egovframework.let.sec.ram.service.AuthorRoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorRoleManageMapper">
 
 
     <resultMap id="authorRole" type="egovframework.let.sec.ram.service.AuthorRoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/ram/EgovAuthorRoleManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorRoleManageDAO">
+<mapper namespace="egovframework.let.sec.ram.service.impl.AuthorRoleManageMapper">
 
 
     <resultMap id="authorRole" type="egovframework.let.sec.ram.service.AuthorRoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,12 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 Mapper 인터페이스 자동 스캔 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: sec(gmt·ram·rgm·rmt) 5개 DAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, context-mapper.xml MapperScannerConfigurer 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 참고
- 동일 리포 다른 @EgovMapper PR과 context-mapper.xml MapperScannerConfigurer가 중복될 수 있어 선행 PR 머지 후 rebase 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
