### PR TITLE
[refactor][공통컴포넌트] cop 게시판/템플릿 4개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageDAO.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageDAO.java
@@ -2,15 +2,15 @@ package egovframework.let.cop.bbs.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.bbs.service.BoardMaster;
 import egovframework.let.cop.bbs.service.BoardMasterVO;
+import jakarta.annotation.Resource;
 
 /**
  * 게시판 속성정보 관리를 위한 데이터 접근 클래스
- * 
+ *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009.03.12
  * @version 1.0
@@ -27,7 +27,10 @@ import egovframework.let.cop.bbs.service.BoardMasterVO;
  *      </pre>
  */
 @Repository("BBSAttributeManageDAO")
-public class BBSAttributeManageDAO extends EgovAbstractMapper {
+public class BBSAttributeManageDAO {
+
+	@Resource
+	private BBSAttributeManageMapper bbsAttributeManageMapper;
 
 	/**
 	 * 등록된 게시판 속성정보를 삭제한다.
@@ -35,7 +38,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMaster
 	 */
 	public void deleteBBSMasterInf(BoardMaster boardMaster) throws Exception {
-		update("BBSAttributeManageDAO.deleteBBSMasterInf", boardMaster);
+		bbsAttributeManageMapper.deleteBBSMasterInf(boardMaster);
 	}
 
 	/**
@@ -44,7 +47,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMaster
 	 */
 	public int insertBBSMasterInf(BoardMaster boardMaster) throws Exception {
-		return insert("BBSAttributeManageDAO.insertBBSMasterInf", boardMaster);
+		return bbsAttributeManageMapper.insertBBSMasterInf(boardMaster);
 	}
 
 	/**
@@ -53,7 +56,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMasterVO
 	 */
 	public BoardMasterVO selectBBSMasterInf(BoardMaster vo) throws Exception {
-		return (BoardMasterVO) selectOne("BBSAttributeManageDAO.selectBBSMasterInf", vo);
+		return bbsAttributeManageMapper.selectBBSMasterInf(vo);
 	}
 
 	/**
@@ -62,7 +65,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMasterVO
 	 */
 	public List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectBBSMasterInfs", vo);
+		return bbsAttributeManageMapper.selectBBSMasterInfs(vo);
 	}
 
 	/**
@@ -73,7 +76,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public int selectBBSMasterInfsCnt(BoardMasterVO vo) throws Exception {
-		return (Integer) selectOne("BBSAttributeManageDAO.selectBBSMasterInfsCnt", vo);
+		return bbsAttributeManageMapper.selectBBSMasterInfsCnt(vo);
 	}
 
 	/**
@@ -82,7 +85,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMaster
 	 */
 	public void updateBBSMasterInf(BoardMaster boardMaster) throws Exception {
-		update("BBSAttributeManageDAO.updateBBSMasterInf", boardMaster);
+		bbsAttributeManageMapper.updateBBSMasterInf(boardMaster);
 	}
 
 	/**
@@ -103,7 +106,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 */
 	public List<BoardMasterVO> selectAllBBSMasteInf(BoardMasterVO vo) throws Exception {
 		// 커뮤니티, 동호회의 게시판이 나오지 않도록 LETTNBBSUSE 테이블과 Join 필요
-		return selectList("BBSAttributeManageDAO.selectAllBBSMaster", vo);
+		return bbsAttributeManageMapper.selectAllBBSMaster(vo);
 	}
 
 	/**
@@ -112,7 +115,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMasterVO
 	 */
 	public List<BoardMasterVO> selectBdMstrListByTrget(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectBdMstrListByTrget", vo);
+		return bbsAttributeManageMapper.selectBdMstrListByTrget(vo);
 	}
 
 	/**
@@ -123,7 +126,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public int selectBdMstrListCntByTrget(BoardMasterVO vo) throws Exception {
-		return (Integer) selectOne("BBSAttributeManageDAO.selectBdMstrListCntByTrget", vo);
+		return bbsAttributeManageMapper.selectBdMstrListCntByTrget(vo);
 	}
 
 	/**
@@ -134,7 +137,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public List<BoardMasterVO> selectAllBdMstrByTrget(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectAllBdMstrByTrget", vo);
+		return bbsAttributeManageMapper.selectAllBdMstrByTrget(vo);
 	}
 
 	/**
@@ -143,7 +146,7 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @param BoardMasterVO
 	 */
 	public List<BoardMasterVO> selectNotUsedBdMstrList(BoardMasterVO vo) throws Exception {
-		return selectList("BBSAttributeManageDAO.selectNotUsedBdMstrList", vo);
+		return bbsAttributeManageMapper.selectNotUsedBdMstrList(vo);
 	}
 
 	/**
@@ -154,6 +157,6 @@ public class BBSAttributeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public int selectNotUsedBdMstrListCnt(BoardMasterVO vo) throws Exception {
-		return (Integer) selectOne("BBSAttributeManageDAO.selectNotUsedBdMstrListCnt", vo);
+		return bbsAttributeManageMapper.selectNotUsedBdMstrListCnt(vo);
 	}
 }

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageMapper.java
@@ -1,0 +1,125 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.service.BoardMaster;
+import egovframework.let.cop.bbs.service.BoardMasterVO;
+
+/**
+ * 게시판 속성정보 관리를 위한 Mapper 인터페이스
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.12
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.12  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *      </pre>
+ */
+@EgovMapper
+public interface BBSAttributeManageMapper {
+
+	/**
+	 * 등록된 게시판 속성정보를 삭제한다.
+	 *
+	 * @param BoardMaster
+	 */
+	void deleteBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 신규 게시판 속성정보를 등록한다.
+	 *
+	 * @param BoardMaster
+	 */
+	int insertBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 게시판 속성정보 한 건을 상세조회 한다.
+	 *
+	 * @param BoardMasterVO
+	 */
+	BoardMasterVO selectBBSMasterInf(BoardMaster vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param BoardMasterVO
+	 */
+	List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보 목록 숫자를 조회한다
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	int selectBBSMasterInfsCnt(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보를 수정한다.
+	 *
+	 * @param BoardMaster
+	 */
+	void updateBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 유효한 게시판 목록을 불러온다.
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectAllBBSMaster(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용중인 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param BoardMasterVO
+	 */
+	List<BoardMasterVO> selectBdMstrListByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용중인 게시판 속성정보 목록 숫자를 조회한다
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	int selectBdMstrListCntByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회등 게시판 사용등록이 된 게시판 목록 전체를 불러온다.
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectAllBdMstrByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용 중이지 않은 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param BoardMasterVO
+	 */
+	List<BoardMasterVO> selectNotUsedBdMstrList(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용 중이지 않은 게시판 속성정보 목록 숫자를 조회한다
+	 *
+	 * @param vo
+	 * @return
+	 * @throws Exception
+	 */
+	int selectNotUsedBdMstrListCnt(BoardMasterVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageDAO.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageDAO.java
@@ -1,12 +1,13 @@
 package egovframework.let.cop.bbs.service.impl;
+
 import java.util.Iterator;
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.bbs.service.Board;
 import egovframework.let.cop.bbs.service.BoardVO;
+import jakarta.annotation.Resource;
 
 /**
  * 게시물 관리를 위한 데이터 접근 클래스
@@ -26,7 +27,10 @@ import egovframework.let.cop.bbs.service.BoardVO;
  *  </pre>
  */
 @Repository("BBSManageDAO")
-public class BBSManageDAO extends EgovAbstractMapper {
+public class BBSManageDAO {
+
+    @Resource
+    private BBSManageMapper bbsManageMapper;
 
     /**
      * 게시판에 게시물을 등록 한다.
@@ -35,10 +39,9 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertBoardArticle(Board board) throws Exception {
-    	long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
-    	board.setNttId(nttId);
-
-    	insert("BBSManageDAO.insertBoardArticle", board);
+        long nttId = bbsManageMapper.selectMaxNttId();
+        board.setNttId(nttId);
+        bbsManageMapper.insertBoardArticle(board);
     }
 
     /**
@@ -48,24 +51,24 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public long replyBoardArticle(Board board) throws Exception {
-		long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
-		board.setNttId(nttId);
-	
-		insert("BBSManageDAO.replyBoardArticle", board);
-	
-		//----------------------------------------------------------
-		// 현재 글 이후 게시물에 대한 NTT_NO를 증가 (정렬을 추가하기 위해)
-		//----------------------------------------------------------
-		//String parentId = board.getParnts();
-		long nttNo = (Long)selectOne("BBSManageDAO.getParentNttNo", board);
-	
-		board.setNttNo(nttNo);
-		update("BBSManageDAO.updateOtherNttNo", board);
-	
-		board.setNttNo(nttNo + 1);
-		update("BBSManageDAO.updateNttNo", board);
-	
-		return nttId;
+        long nttId = bbsManageMapper.selectMaxNttId();
+        board.setNttId(nttId);
+
+        bbsManageMapper.replyBoardArticle(board);
+
+        //----------------------------------------------------------
+        // 현재 글 이후 게시물에 대한 NTT_NO를 증가 (정렬을 추가하기 위해)
+        //----------------------------------------------------------
+        //String parentId = board.getParnts();
+        long nttNo = bbsManageMapper.getParentNttNo(board);
+
+        board.setNttNo(nttNo);
+        bbsManageMapper.updateOtherNttNo(board);
+
+        board.setNttNo(nttNo + 1);
+        bbsManageMapper.updateNttNo(board);
+
+        return nttId;
     }
 
     /**
@@ -76,7 +79,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public BoardVO selectBoardArticle(BoardVO boardVO) throws Exception {
-    	return (BoardVO)selectOne("BBSManageDAO.selectBoardArticle", boardVO);
+        return bbsManageMapper.selectBoardArticle(boardVO);
     }
 
     /**
@@ -87,7 +90,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectBoardArticleList(BoardVO boardVO) throws Exception {
-    	return selectList("BBSManageDAO.selectBoardArticleList", boardVO);
+        return bbsManageMapper.selectBoardArticleList(boardVO);
     }
 
     /**
@@ -98,7 +101,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBoardArticleListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectBoardArticleListCnt", boardVO);
+        return bbsManageMapper.selectBoardArticleListCnt(boardVO);
     }
 
     /**
@@ -108,7 +111,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.updateBoardArticle", board);
+        bbsManageMapper.updateBoardArticle(board);
     }
 
     /**
@@ -118,17 +121,17 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.deleteBoardArticle", board);
+        bbsManageMapper.deleteBoardArticle(board);
     }
 
     /**
      * 게시물에 대한 조회 건수를 수정 한다.
      *
-     * @param board
+     * @param boardVO
      * @throws Exception
      */
     public void updateInqireCo(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.updateInqireCo", boardVO);
+        bbsManageMapper.updateInqireCo(boardVO);
     }
 
     /**
@@ -139,18 +142,18 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectMaxInqireCo(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectMaxInqireCo", boardVO);
+        return bbsManageMapper.selectMaxInqireCo(boardVO);
     }
 
     /**
      * 게시판에 대한 목록을 정렬 순서로 조회 한다.
      *
-     * @param boardVO
+     * @param board
      * @return
      * @throws Exception
      */
     public List<BoardVO> selectNoticeListForSort(Board board) throws Exception {
-    	return selectList("BBSManageDAO.selectNoticeListForSort", board);
+        return bbsManageMapper.selectNoticeListForSort(board);
     }
 
     /**
@@ -160,23 +163,21 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateSortOrder(List<BoardVO> sortList) throws Exception {
-    	BoardVO vo;
-    	Iterator<BoardVO> iter = sortList.iterator();
-    	while (iter.hasNext()) {
-    		vo = iter.next();
-    		update("BBSManageDAO.updateSortOrder", vo);
-    	}
+        Iterator<BoardVO> iter = sortList.iterator();
+        while (iter.hasNext()) {
+            bbsManageMapper.updateSortOrder(iter.next());
+        }
     }
 
     /**
      * 게시판에 대한 현재 게시물 번호의 최대값을 구한다.
      *
-     * @param boardVO
+     * @param board
      * @return
      * @throws Exception
      */
     public long selectNoticeItemForSort(Board board) throws Exception {
-    	return (Long)selectOne("BBSManageDAO.selectNoticeItemForSort", board);
+        return bbsManageMapper.selectNoticeItemForSort(board);
     }
 
     /**
@@ -187,7 +188,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectGuestList(BoardVO boardVO) throws Exception {
-    	return selectList("BBSManageDAO.selectGuestList", boardVO);
+        return bbsManageMapper.selectGuestList(boardVO);
     }
 
     /**
@@ -198,7 +199,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectGuestListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectGuestListCnt", boardVO);
+        return bbsManageMapper.selectGuestListCnt(boardVO);
     }
 
     /**
@@ -208,7 +209,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteGuestList(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.deleteGuestList", boardVO);
+        bbsManageMapper.deleteGuestList(boardVO);
     }
 
     /**
@@ -219,6 +220,6 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public String getPasswordInf(Board board) throws Exception {
-    	return (String)selectOne("BBSManageDAO.getPasswordInf", board);
+        return bbsManageMapper.getPasswordInf(board);
     }
 }

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageMapper.java
@@ -1,0 +1,201 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.service.Board;
+import egovframework.let.cop.bbs.service.BoardVO;
+
+/**
+ * 게시물 관리를 위한 Mapper 인터페이스
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.19
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.19  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *  </pre>
+ */
+@EgovMapper
+public interface BBSManageMapper {
+
+	/**
+	 * 게시판에 대한 현재 게시물 번호의 최대값을 구한다.
+	 *
+	 * @return
+	 * @throws Exception
+	 */
+	long selectMaxNttId() throws Exception;
+
+	/**
+	 * 게시판에 게시물을 등록 한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void insertBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시판에 답변 게시물을 등록 한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void replyBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 부모 게시물의 NTT_NO를 조회한다.
+	 *
+	 * @param board
+	 * @return
+	 * @throws Exception
+	 */
+	long getParentNttNo(Board board) throws Exception;
+
+	/**
+	 * 현재 글 이후 게시물에 대한 NTT_NO를 증가한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void updateOtherNttNo(Board board) throws Exception;
+
+	/**
+	 * 게시물의 NTT_NO를 수정한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void updateNttNo(Board board) throws Exception;
+
+	/**
+	 * 게시물 한 건에 대하여 상세 내용을 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	BoardVO selectBoardArticle(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 조건에 맞는 게시물 목록을 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardVO> selectBoardArticleList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 조건에 맞는 게시물 목록에 대한 전체 건수를 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectBoardArticleListCnt(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시물 한 건의 내용을 수정 한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void updateBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시물 한 건을 삭제 한다.
+	 *
+	 * @param board
+	 * @throws Exception
+	 */
+	void deleteBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시물에 대한 조회 건수를 수정 한다.
+	 *
+	 * @param boardVO
+	 * @throws Exception
+	 */
+	void updateInqireCo(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시물에 대한 현재 조회 건수를 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectMaxInqireCo(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시판에 대한 목록을 정렬 순서로 조회 한다.
+	 *
+	 * @param board
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardVO> selectNoticeListForSort(Board board) throws Exception;
+
+	/**
+	 * 게시판에 대한 정렬 순서를 수정 한다.
+	 *
+	 * @param vo
+	 * @throws Exception
+	 */
+	void updateSortOrder(BoardVO vo) throws Exception;
+
+	/**
+	 * 게시판에 대한 현재 게시물 번호의 최대값을 구한다.
+	 *
+	 * @param board
+	 * @return
+	 * @throws Exception
+	 */
+	long selectNoticeItemForSort(Board board) throws Exception;
+
+	/**
+	 * 방명록에 대한 목록을 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardVO> selectGuestList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록에 대한 목록 건수를 조회 한다.
+	 *
+	 * @param boardVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectGuestListCnt(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록 내용을 삭제 한다.
+	 *
+	 * @param boardVO
+	 * @throws Exception
+	 */
+	void deleteGuestList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록에 대한 패스워드를 조회 한다.
+	 *
+	 * @param board
+	 * @return
+	 * @throws Exception
+	 */
+	String getPasswordInf(Board board) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.cop.com.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.com.service.BoardUseInf;
 import egovframework.let.cop.com.service.BoardUseInfVO;
+import jakarta.annotation.Resource;
 
 /**
  * 게시판 이용정보를 관리하기 위한 데이터 접근 클래스
@@ -26,7 +26,10 @@ import egovframework.let.cop.com.service.BoardUseInfVO;
  * </pre>
  */
 @Repository("BBSUseInfoManageDAO")
-public class BBSUseInfoManageDAO extends EgovAbstractMapper {
+public class BBSUseInfoManageDAO {
+
+    @Resource
+    private BBSUseInfoManageMapper bbsUseInfoManageMapper;
 
     /**
      * 게시판 사용 정보를 삭제한다.
@@ -35,47 +38,47 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.deleteBBSUseInf(bdUseInf);
     }
 
     /**
      * 커뮤니티에 사용되는 게시판 사용정보 목록을 조회한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfByCmmnty", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfByCmmnty(bdUseVO);
     }
 
     /**
      * 동호회에 사용되는 게시판 사용정보 목록을 조회한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfByClub", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfByClub(bdUseVO);
     }
 
     /**
      * 커뮤니티에 사용되는 모든 게시판 사용정보를 삭제한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteAllBBSUseInfByCmmnty", bdUseVO);
+        bbsUseInfoManageMapper.deleteAllBBSUseInfByCmmnty(bdUseVO);
     }
 
     /**
      * 동호회에 사용되는 모든 게시판 사용정보를 삭제한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteAllBBSUseInfByClub", bdUseVO);
+        bbsUseInfoManageMapper.deleteAllBBSUseInfByClub(bdUseVO);
     }
 
     /**
@@ -85,7 +88,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	insert("BBSUseInfoManageDAO.insertBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.insertBBSUseInf(bdUseInf);
     }
 
     /**
@@ -96,17 +99,18 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfs", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfs(bdUseVO);
     }
 
     /**
+     * 게시판 사용정보 목록 전체 건수를 조회한다.
      *
      * @param bdUseVO
      * @return
      * @throws Exception
      */
     public int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception {
-    	return (Integer)selectOne("BBSUseInfoManageDAO.selectBBSUseInfsCnt", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsCnt(bdUseVO);
     }
 
     /**
@@ -117,7 +121,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception {
-    	return (BoardUseInfVO)selectOne("BBSUseInfoManageDAO.selectBBSUseInf", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInf(bdUseVO);
     }
 
     /**
@@ -127,7 +131,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.updateBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.updateBBSUseInf(bdUseInf);
     }
 
     /**
@@ -137,7 +141,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteBBSUseInfByBoardId", bdUseInf);
+        bbsUseInfoManageMapper.deleteBBSUseInfByBoardId(bdUseInf);
     }
 
     /**
@@ -148,7 +152,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfsByTrget", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsByTrget(bdUseVO);
     }
 
     /**
@@ -159,7 +163,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception {
-    	return (Integer)selectOne("BBSUseInfoManageDAO.selectBBSUseInfsCntByTrget", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsCntByTrget(bdUseVO);
     }
 
     /**
@@ -169,6 +173,6 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.updateBBSUseInfByTrget", bdUseInf);
+        bbsUseInfoManageMapper.updateBBSUseInfByTrget(bdUseInf);
     }
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
@@ -1,0 +1,148 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.BoardUseInf;
+import egovframework.let.cop.com.service.BoardUseInfVO;
+
+/**
+ * 게시판 이용정보를 관리하기 위한 Mapper 인터페이스
+ *
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.04.02
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *   2009.04.02  이삼섭          최초 생성
+ *   2011.05.31  JJY           경량환경 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface BBSUseInfoManageMapper {
+
+	/**
+	 * 게시판 사용 정보를 삭제한다.
+	 *
+	 * @param bdUseInf
+	 * @throws Exception
+	 */
+	void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 커뮤니티에 사용되는 게시판 사용정보 목록을 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @throws Exception
+	 */
+	List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 동호회에 사용되는 게시판 사용정보 목록을 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @throws Exception
+	 */
+	List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티에 사용되는 모든 게시판 사용정보를 삭제한다.
+	 *
+	 * @param bdUseVO
+	 * @throws Exception
+	 */
+	void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 동호회에 사용되는 모든 게시판 사용정보를 삭제한다.
+	 *
+	 * @param bdUseVO
+	 * @throws Exception
+	 */
+	void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보를 등록한다.
+	 *
+	 * @param bdUseInf
+	 * @throws Exception
+	 */
+	void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 게시판 사용정보 목록을 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보 목록 전체 건수를 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보에 대한 상세정보를 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @return
+	 * @throws Exception
+	 */
+	BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보를 수정한다.
+	 *
+	 * @param bdUseInf
+	 * @throws Exception
+	 */
+	void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 게시판에 대한 사용정보를 삭제한다.
+	 *
+	 * @param bdUseInf
+	 * @throws Exception
+	 */
+	void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 목록을 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 전체 건수를 조회한다.
+	 *
+	 * @param bdUseVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보를 수정한다.
+	 *
+	 * @param bdUseInf
+	 * @throws Exception
+	 */
+	void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageDAO.java
@@ -1,11 +1,12 @@
 package egovframework.let.cop.com.service.impl;
+
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.com.service.TemplateInf;
 import egovframework.let.cop.com.service.TemplateInfVO;
+import jakarta.annotation.Resource;
 
 /**
  * 템플릿 정보관리를 위한 데이터 접근 클래스
@@ -25,7 +26,10 @@ import egovframework.let.cop.com.service.TemplateInfVO;
  * </pre>
  */
 @Repository("TemplateManageDAO")
-public class TemplateManageDAO extends EgovAbstractMapper {
+public class TemplateManageDAO {
+
+    @Resource
+    private TemplateManageMapper templateManageMapper;
 
     /**
      * 템플릿 정보를 삭제한다.
@@ -34,7 +38,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	update("TemplateManageDAO.deleteTemplateInf", tmplatInf);
+        templateManageMapper.deleteTemplateInf(tmplatInf);
     }
 
     /**
@@ -44,7 +48,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	insert("TemplateManageDAO.insertTemplateInf", tmplatInf);
+        templateManageMapper.insertTemplateInf(tmplatInf);
     }
 
     /**
@@ -54,18 +58,18 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	update("TemplateManageDAO.updateTemplateInf", tmplatInf);
+        templateManageMapper.updateTemplateInf(tmplatInf);
     }
 
     /**
-     * 템플릿에 대한 목록를 조회한다.
+     * 템플릿에 대한 목록을 조회한다.
      *
      * @param tmplatInfVO
      * @return
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO) throws Exception {
-    	return selectList("TemplateManageDAO.selectTemplateInfs", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfs(tmplatInfVO);
     }
 
     /**
@@ -76,7 +80,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO) throws Exception {
-    	return (Integer)selectOne("TemplateManageDAO.selectTemplateInfsCnt", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsCnt(tmplatInfVO);
     }
 
     /**
@@ -87,8 +91,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO) throws Exception {
-    	return (TemplateInfVO)selectOne("TemplateManageDAO.selectTemplateInf", tmplatInfVO);
-
+        return templateManageMapper.selectTemplateInf(tmplatInfVO);
     }
 
     /**
@@ -99,7 +102,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public TemplateInfVO selectTemplatePreview(TemplateInfVO tmplatInfVO) throws Exception {
-    	return null;
+        return null;
     }
 
     /**
@@ -110,7 +113,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO) throws Exception {
-    	return selectList("TemplateManageDAO.selectTemplateInfsByCode", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsByCode(tmplatInfVO);
     }
 
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageMapper.java
@@ -1,0 +1,91 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.TemplateInf;
+import egovframework.let.cop.com.service.TemplateInfVO;
+
+/**
+ * 템플릿 정보관리를 위한 Mapper 인터페이스
+ *
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.03.17
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.17  이삼섭          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface TemplateManageMapper {
+
+	/**
+	 * 템플릿 정보를 삭제한다.
+	 *
+	 * @param tmplatInf
+	 * @throws Exception
+	 */
+	void deleteTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿 정보를 등록한다.
+	 *
+	 * @param tmplatInf
+	 * @throws Exception
+	 */
+	void insertTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿 정보를 수정한다.
+	 *
+	 * @param tmplatInf
+	 * @throws Exception
+	 */
+	void updateTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿에 대한 목록을 조회한다.
+	 *
+	 * @param tmplatInfVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿에 대한 목록 전체 건수를 조회한다.
+	 *
+	 * @param tmplatInfVO
+	 * @return
+	 * @throws Exception
+	 */
+	int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿에 대한 상세정보를 조회한다.
+	 *
+	 * @param tmplatInfVO
+	 * @return
+	 * @throws Exception
+	 */
+	TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿 구분에 따른 목록을 조회한다.
+	 *
+	 * @param tmplatInfVO
+	 * @return
+	 * @throws Exception
+	 */
+	List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.service.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.service.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.service.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.service.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSManageMapper">
 
 
 	<resultMap id="boardList" type="egovframework.let.cop.bbs.service.BoardVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovBBSUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSUseInfoManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.BBSUseInfoManageMapper">
 
 
 	<resultMap id="BoardUseList" type="egovframework.let.cop.com.service.BoardUseInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.TemplateManageMapper">
 
 
 	<resultMap id="tmplatList" type="egovframework.let.cop.com.service.TemplateInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.TemplateManageMapper">
 
 
 	<resultMap id="tmplatList" type="egovframework.let.cop.com.service.TemplateInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.TemplateManageMapper">
 
 
 	<resultMap id="tmplatList" type="egovframework.let.cop.com.service.TemplateInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.TemplateManageMapper">
 
 
 	<resultMap id="tmplatList" type="egovframework.let.cop.com.service.TemplateInfVO">

--- a/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/com/EgovTemplate_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="TemplateManageDAO">
+<mapper namespace="egovframework.let.cop.com.service.impl.TemplateManageMapper">
 
 
 	<resultMap id="tmplatList" type="egovframework.let.cop.com.service.TemplateInfVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,12 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 Mapper 인터페이스 자동 스캔 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: cop(BBSAttribute·BBSManage·BBSUseInfo·Template) 4개 DAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, context-mapper.xml MapperScannerConfigurer 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 참고
- 동일 리포 다른 @EgovMapper PR과 context-mapper.xml MapperScannerConfigurer가 중복될 수 있어 선행 PR 머지 후 rebase 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
