### PR TITLE
[refactor][공통컴포넌트] sym·uat·uss·olh·olp 12개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageDAO.java
@@ -2,7 +2,8 @@ package egovframework.let.sym.ccm.zip.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.ccm.zip.service.Zip;
@@ -27,7 +28,10 @@ import egovframework.let.sym.ccm.zip.service.ZipVO;
  * </pre>
  */
 @Repository("ZipManageDAO")
-public class ZipManageDAO extends EgovAbstractMapper {
+public class ZipManageDAO {
+
+	@Resource
+	private ZipManageMapper zipManageMapper;
 
 	/**
 	 * 우편번호를 삭제한다.
@@ -35,7 +39,7 @@ public class ZipManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void deleteZip(Zip zip) throws Exception {
-		delete("ZipManageDAO.deleteZip", zip);
+		zipManageMapper.deleteZip(zip);
 	}
 
 	/**
@@ -43,7 +47,7 @@ public class ZipManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void deleteAllZip() throws Exception {
-		delete("ZipManageDAO.deleteAllZip", new Object());
+		zipManageMapper.deleteAllZip();
 	}
 
 	/**
@@ -52,18 +56,16 @@ public class ZipManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void insertZip(Zip zip) throws Exception {
-        insert("ZipManageDAO.insertZip", zip);
+		zipManageMapper.insertZip(zip);
 	}
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.
-	 * @param zip
 	 * @throws Exception
 	 */
 	public void insertExcelZip() throws Exception {
-		delete("ZipManageDAO.deleteAllZip", new Object());
+		zipManageMapper.insertExcelZip();
 	}
-
 
 	/**
 	 * 우편번호 상세항목을 조회한다.
@@ -71,28 +73,27 @@ public class ZipManageDAO extends EgovAbstractMapper {
 	 * @return Zip(우편번호)
 	 */
 	public Zip selectZipDetail(Zip zip) throws Exception {
-		return (Zip) selectOne("ZipManageDAO.selectZipDetail", zip);
+		return zipManageMapper.selectZipDetail(zip);
 	}
 
-
-    /**
+	/**
 	 * 우편번호 목록을 조회한다.
-     * @param searchVO
-     * @return List(우편번호 목록)
-     * @throws Exception
-     */
-    public List<?> selectZipList(ZipVO searchVO) throws Exception {
-        return selectList("ZipManageDAO.selectZipList", searchVO);
-    }
+	 * @param searchVO
+	 * @return List(우편번호 목록)
+	 * @throws Exception
+	 */
+	public List<?> selectZipList(ZipVO searchVO) throws Exception {
+		return zipManageMapper.selectZipList(searchVO);
+	}
 
-    /**
+	/**
 	 * 우편번호 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(우편번호 총 갯수)
-     */
-    public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
-        return (Integer)selectOne("ZipManageDAO.selectZipListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(우편번호 총 갯수)
+	 */
+	public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
+		return zipManageMapper.selectZipListTotCnt(searchVO);
+	}
 
 	/**
 	 * 우편번호를 수정한다.
@@ -100,7 +101,7 @@ public class ZipManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void updateZip(Zip zip) throws Exception {
-		update("ZipManageDAO.updateZip", zip);
+		zipManageMapper.updateZip(zip);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageMapper.java
@@ -1,0 +1,35 @@
+package egovframework.let.sym.ccm.zip.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.ccm.zip.service.Zip;
+import egovframework.let.sym.ccm.zip.service.ZipVO;
+
+/**
+ * 우편번호에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ */
+@EgovMapper
+public interface ZipManageMapper {
+
+	void deleteZip(Zip zip) throws Exception;
+
+	void deleteAllZip() throws Exception;
+
+	void insertZip(Zip zip) throws Exception;
+
+	void insertExcelZip() throws Exception;
+
+	Zip selectZipDetail(Zip zip) throws Exception;
+
+	List<?> selectZipList(ZipVO searchVO) throws Exception;
+
+	int selectZipListTotCnt(ZipVO searchVO) throws Exception;
+
+	void updateZip(Zip zip) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageDAO.java
+++ b/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageDAO.java
@@ -2,10 +2,12 @@ package egovframework.let.sym.mnu.mpm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
+
 /**
  * 메뉴관리, 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다.
  * @author 개발환경 개발팀 이용
@@ -19,15 +21,16 @@ import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
- *   2011.07.01  서준식			자기 메뉴 정보를 상위메뉴 정보로 참조하는 메뉴정보가 있는지 조회하는
- *   							selectUpperMenuNoByPk() 메서드 추가
+ *   2011.07.01  서준식          selectUpperMenuNoByPk() 메서드 추가
  *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
 @Repository("menuManageDAO")
-public class MenuManageDAO extends EgovAbstractMapper{
+public class MenuManageDAO {
+
+	@Resource
+	private MenuManageMapper menuManageMapper;
 
 	/*### 메뉴관련 프로세스 ###*/
 	/**
@@ -36,8 +39,8 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectMainMenuHead(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuHead", vo);
+	public List<?> selectMainMenuHead(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuHead(vo);
 	}
 
 	/**
@@ -46,18 +49,18 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuLeft", vo);
+	public List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuLeft(vo);
 	}
 
 	/**
 	 * MainMenu Head MenuURL 조회
 	 * @param vo MenuManageVO
-	 * @return  String
+	 * @return String
 	 * @exception Exception
 	 */
-	public String selectLastMenuURL(MenuManageVO vo) throws Exception{
-		return (String)selectOne("menuManageDAO.selectLastMenuURL", vo);
+	public String selectLastMenuURL(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuURL(vo);
 	}
 
 	/**
@@ -66,8 +69,8 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectLastMenuNo(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNo", vo);
+	public int selectLastMenuNo(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuNo(vo);
 	}
 
 	/**
@@ -76,8 +79,8 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectLastMenuNoCnt(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNoCnt", vo);
+	public int selectLastMenuNoCnt(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuNoCnt(vo);
 	}
 
 	/**
@@ -86,8 +89,8 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectMainMenuHeadByAuthor(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuHeadByAuthor", vo);
+	public List<?> selectMainMenuHeadByAuthor(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuHeadByAuthor(vo);
 	}
 
 	/**
@@ -96,8 +99,8 @@ public class MenuManageDAO extends EgovAbstractMapper{
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<?> selectMainMenuLeftByAuthor(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuLeftByAuthor", vo);
+	public List<?> selectMainMenuLeftByAuthor(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuLeftByAuthor(vo);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageMapper.java
+++ b/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageMapper.java
@@ -1,0 +1,32 @@
+package egovframework.let.sym.mnu.mpm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
+
+/**
+ * 메뉴관리, 메뉴생성, 사이트맵 생성에 대한 Mapper 인터페이스를 정의한다.
+ * @author 개발환경 개발팀 이용
+ * @since 2009.06.01
+ * @version 1.0
+ */
+@EgovMapper
+public interface MenuManageMapper {
+
+	List<?> selectMainMenuHead(MenuManageVO vo) throws Exception;
+
+	List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception;
+
+	String selectLastMenuURL(MenuManageVO vo) throws Exception;
+
+	int selectLastMenuNo(MenuManageVO vo) throws Exception;
+
+	int selectLastMenuNoCnt(MenuManageVO vo) throws Exception;
+
+	List<?> selectMainMenuHeadByAuthor(MenuManageVO vo) throws Exception;
+
+	List<?> selectMainMenuLeftByAuthor(MenuManageVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginDAO.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginDAO.java
@@ -1,6 +1,7 @@
 package egovframework.let.uat.uia.service.impl;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.LoginVO;
@@ -23,7 +24,10 @@ import egovframework.com.cmm.LoginVO;
  *  </pre>
  */
 @Repository("loginDAO")
-public class LoginDAO extends EgovAbstractMapper {
+public class LoginDAO {
+
+	@Resource
+	private LoginMapper loginMapper;
 
 	/**
 	 * 일반 로그인을 처리한다
@@ -32,7 +36,7 @@ public class LoginDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public LoginVO actionLogin(LoginVO vo) throws Exception {
-		return (LoginVO) selectOne("loginDAO.actionLogin", vo);
+		return loginMapper.actionLogin(vo);
 	}
 
 	/**
@@ -42,7 +46,7 @@ public class LoginDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public LoginVO searchId(LoginVO vo) throws Exception {
-		return (LoginVO) selectOne("loginDAO.searchId", vo);
+		return loginMapper.searchId(vo);
 	}
 
 	/**
@@ -52,7 +56,7 @@ public class LoginDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public LoginVO searchPassword(LoginVO vo) throws Exception {
-		return (LoginVO) selectOne("loginDAO.searchPassword", vo);
+		return loginMapper.searchPassword(vo);
 	}
 
 	/**
@@ -61,6 +65,6 @@ public class LoginDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public void updatePassword(LoginVO vo) throws Exception {
-		update("loginDAO.updatePassword", vo);
+		loginMapper.updatePassword(vo);
 	}
 }

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
@@ -1,0 +1,24 @@
+package egovframework.let.uat.uia.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.LoginVO;
+
+/**
+ * 일반 로그인을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.06
+ * @version 1.0
+ */
+@EgovMapper
+public interface LoginMapper {
+
+	LoginVO actionLogin(LoginVO vo) throws Exception;
+
+	LoginVO searchId(LoginVO vo) throws Exception;
+
+	LoginVO searchPassword(LoginVO vo) throws Exception;
+
+	void updatePassword(LoginVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/ion/bnr/service/impl/BannerDAO.java
+++ b/src/main/java/egovframework/let/uss/ion/bnr/service/impl/BannerDAO.java
@@ -2,12 +2,14 @@ package egovframework.let.uss.ion.bnr.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.FileVO;
 import egovframework.let.uss.ion.bnr.service.Banner;
 import egovframework.let.uss.ion.bnr.service.BannerVO;
+
 /**
  * 배너에 대한 DAO 클래스를 정의한다.
  * 배너에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
@@ -28,7 +30,10 @@ import egovframework.let.uss.ion.bnr.service.BannerVO;
  * </pre>
  */
 @Repository("bannerDAO")
-public class BannerDAO extends EgovAbstractMapper {
+public class BannerDAO {
+
+	@Resource
+	private BannerMapper bannerMapper;
 
 	/**
 	 * 배너를 관리하기 위해 등록된 배너목록을 조회한다.
@@ -37,28 +42,26 @@ public class BannerDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<BannerVO> selectBannerList(BannerVO bannerVO) throws Exception {
-		return selectList("bannerDAO.selectBannerList", bannerVO);
+		return bannerMapper.selectBannerList(bannerVO);
 	}
 
-    /**
+	/**
 	 * 배너목록 총 갯수를 조회한다.
 	 * @param bannerVO BannerVO
 	 * @return int
 	 * @exception Exception
 	 */
-    public int selectBannerListTotCnt(BannerVO bannerVO) throws Exception {
-        return (Integer)selectOne("bannerDAO.selectBannerListTotCnt", bannerVO);
-    }
+	public int selectBannerListTotCnt(BannerVO bannerVO) throws Exception {
+		return bannerMapper.selectBannerListTotCnt(bannerVO);
+	}
 
 	/**
 	 * 등록된 배너의 상세정보를 조회한다.
 	 * @param bannerVO - 배너 Vo
 	 * @return BannerVO - 배너 Vo
-	 *
-	 * @param bannerVO
 	 */
 	public BannerVO selectBanner(BannerVO bannerVO) throws Exception {
-		return (BannerVO) selectOne("bannerDAO.selectBanner", bannerVO);
+		return bannerMapper.selectBanner(bannerVO);
 	}
 
 	/**
@@ -66,7 +69,7 @@ public class BannerDAO extends EgovAbstractMapper {
 	 * @param banner - 배너 model
 	 */
 	public void insertBanner(Banner banner) throws Exception {
-		insert("bannerDAO.insertBanner", banner);
+		bannerMapper.insertBanner(banner);
 	}
 
 	/**
@@ -74,17 +77,15 @@ public class BannerDAO extends EgovAbstractMapper {
 	 * @param banner - 배너 model
 	 */
 	public void updateBanner(Banner banner) throws Exception {
-        update("bannerDAO.updateBanner", banner);
+		bannerMapper.updateBanner(banner);
 	}
 
 	/**
 	 * 기 등록된 배너정보를 삭제한다.
 	 * @param banner - 배너 model
-	 *
-	 * @param banner
 	 */
 	public void deleteBanner(Banner banner) throws Exception {
-		delete("bannerDAO.deleteBanner", banner);
+		bannerMapper.deleteBanner(banner);
 	}
 
 	/**
@@ -93,7 +94,7 @@ public class BannerDAO extends EgovAbstractMapper {
 	 * @return FileVO - 파일 VO
 	 */
 	public FileVO selectBannerFile(Banner banner) throws Exception {
-		return (FileVO) selectOne("bannerDAO.selectBannerFile", banner);
+		return bannerMapper.selectBannerFile(banner);
 	}
 
 	/**
@@ -103,7 +104,7 @@ public class BannerDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
 	public List<BannerVO> selectBannerResult(BannerVO bannerVO) throws Exception {
-		return selectList("bannerDAO.selectBannerResult", bannerVO);
+		return bannerMapper.selectBannerResult(bannerVO);
 	}
 
 }

--- a/src/main/java/egovframework/let/uss/ion/bnr/service/impl/BannerMapper.java
+++ b/src/main/java/egovframework/let/uss/ion/bnr/service/impl/BannerMapper.java
@@ -1,0 +1,36 @@
+package egovframework.let.uss.ion.bnr.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.service.FileVO;
+import egovframework.let.uss.ion.bnr.service.Banner;
+import egovframework.let.uss.ion.bnr.service.BannerVO;
+
+/**
+ * 배너에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스개발팀 lee.m.j
+ * @since 2009.08.03
+ * @version 1.0
+ */
+@EgovMapper
+public interface BannerMapper {
+
+	List<BannerVO> selectBannerList(BannerVO bannerVO) throws Exception;
+
+	int selectBannerListTotCnt(BannerVO bannerVO) throws Exception;
+
+	BannerVO selectBanner(BannerVO bannerVO) throws Exception;
+
+	void insertBanner(Banner banner) throws Exception;
+
+	void updateBanner(Banner banner) throws Exception;
+
+	void deleteBanner(Banner banner) throws Exception;
+
+	FileVO selectBannerFile(Banner banner) throws Exception;
+
+	List<BannerVO> selectBannerResult(BannerVO bannerVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageDAO.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageDAO.java
@@ -2,11 +2,13 @@ package egovframework.let.uss.olh.faq.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.olh.faq.service.FaqManageDefaultVO;
 import egovframework.let.uss.olh.faq.service.FaqManageVO;
+
 /**
  *
  * FAQ를 처리하는 DAO 클래스
@@ -26,86 +28,74 @@ import egovframework.let.uss.olh.faq.service.FaqManageVO;
  * </pre>
  */
 @Repository("FaqManageDAO")
-public class FaqManageDAO extends EgovAbstractMapper {
+public class FaqManageDAO {
 
+	@Resource
+	private FaqManageMapper faqManageMapper;
 
-    /**
+	/**
 	 * FAQ 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
-    public FaqManageVO selectFaqListDetail(FaqManageVO vo) throws Exception {
-
-        return (FaqManageVO) selectOne("FaqManageDAO.selectFaqListDetail", vo);
-
-    }
+	public FaqManageVO selectFaqListDetail(FaqManageVO vo) throws Exception {
+		return faqManageMapper.selectFaqListDetail(vo);
+	}
 
 	/**
 	 * FAQ 조회수를 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateFaqInqireCo(FaqManageVO vo) throws Exception {
+	public void updateFaqInqireCo(FaqManageVO vo) throws Exception {
+		faqManageMapper.updateFaqInqireCo(vo);
+	}
 
-        update("FaqManageDAO.updateFaqInqireCo", vo);
-
-    }
-
-    /**
+	/**
 	 * FAQ 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
 	 * @exception Exception
 	 */
 	public List<?> selectFaqList(FaqManageDefaultVO searchVO) throws Exception {
+		return faqManageMapper.selectFaqList(searchVO);
+	}
 
-        return selectList("FaqManageDAO.selectFaqList", searchVO);
-
-    }
-
-    /**
+	/**
 	 * FAQ 글 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 갯수
 	 */
-    public int selectFaqListTotCnt(FaqManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("FaqManageDAO.selectFaqListTotCnt", searchVO);
-
-    }
+	public int selectFaqListTotCnt(FaqManageDefaultVO searchVO) {
+		return faqManageMapper.selectFaqListTotCnt(searchVO);
+	}
 
 	/**
 	 * FAQ 글을 등록한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void insertFaqCn(FaqManageVO vo) throws Exception {
-
-        insert("FaqManageDAO.insertFaqCn", vo);
-
-    }
+	public void insertFaqCn(FaqManageVO vo) throws Exception {
+		faqManageMapper.insertFaqCn(vo);
+	}
 
 	/**
 	 * FAQ 글을 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateFaqCn(FaqManageVO vo) throws Exception {
-
-        update("FaqManageDAO.updateFaqCn", vo);
-
-    }
+	public void updateFaqCn(FaqManageVO vo) throws Exception {
+		faqManageMapper.updateFaqCn(vo);
+	}
 
 	/**
 	 * FAQ 글을 삭제한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void deleteFaqCn(FaqManageVO vo) throws Exception {
-
-        delete("FaqManageDAO.deleteFaqCn", vo);
-
-    }
+	public void deleteFaqCn(FaqManageVO vo) throws Exception {
+		faqManageMapper.deleteFaqCn(vo);
+	}
 
 }

--- a/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olh/faq/service/impl/FaqManageMapper.java
@@ -1,0 +1,33 @@
+package egovframework.let.uss.olh.faq.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.olh.faq.service.FaqManageDefaultVO;
+import egovframework.let.uss.olh.faq.service.FaqManageVO;
+
+/**
+ * FAQ를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ */
+@EgovMapper
+public interface FaqManageMapper {
+
+	FaqManageVO selectFaqListDetail(FaqManageVO vo) throws Exception;
+
+	void updateFaqInqireCo(FaqManageVO vo) throws Exception;
+
+	List<?> selectFaqList(FaqManageDefaultVO searchVO) throws Exception;
+
+	int selectFaqListTotCnt(FaqManageDefaultVO searchVO);
+
+	void insertFaqCn(FaqManageVO vo) throws Exception;
+
+	void updateFaqCn(FaqManageVO vo) throws Exception;
+
+	void deleteFaqCn(FaqManageVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olh/qna/service/impl/QnaManageDAO.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/impl/QnaManageDAO.java
@@ -2,11 +2,13 @@ package egovframework.let.uss.olh.qna.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.olh.qna.service.QnaManageDefaultVO;
 import egovframework.let.uss.olh.qna.service.QnaManageVO;
+
 /**
  *
  * Q&A정보를 처리하는 DAO 클래스
@@ -26,146 +28,121 @@ import egovframework.let.uss.olh.qna.service.QnaManageVO;
  * </pre>
  */
 @Repository("QnaManageDAO")
-public class QnaManageDAO extends EgovAbstractMapper {
+public class QnaManageDAO {
 
+	@Resource
+	private QnaManageMapper qnaManageMapper;
 
-    /**
+	/**
 	 * Q&A 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
-    public QnaManageVO selectQnaListDetail(QnaManageVO vo) throws Exception {
-
-        return (QnaManageVO) selectOne("QnaManageDAO.selectQnaListDetail", vo);
-
-    }
+	public QnaManageVO selectQnaListDetail(QnaManageVO vo) throws Exception {
+		return qnaManageMapper.selectQnaListDetail(vo);
+	}
 
 	/**
 	 * Q&A 글을 수정한다.(조회수를 수정)
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateQnaInqireCo(QnaManageVO vo) throws Exception {
+	public void updateQnaInqireCo(QnaManageVO vo) throws Exception {
+		qnaManageMapper.updateQnaInqireCo(vo);
+	}
 
-        update("QnaManageDAO.updateQnaInqireCo", vo);
-
-    }
-
-    /**
+	/**
 	 * Q&A 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
 	 * @exception Exception
 	 */
 	public List<?> selectQnaList(QnaManageDefaultVO searchVO) throws Exception {
+		return qnaManageMapper.selectQnaList(searchVO);
+	}
 
-        return selectList("QnaManageDAO.selectQnaList", searchVO);
-
-    }
-
-    /**
+	/**
 	 * Q&A 글 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 갯수
 	 */
-    public int selectQnaListTotCnt(QnaManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("QnaManageDAO.selectQnaListTotCnt", searchVO);
-
-    }
+	public int selectQnaListTotCnt(QnaManageDefaultVO searchVO) {
+		return qnaManageMapper.selectQnaListTotCnt(searchVO);
+	}
 
 	/**
 	 * Q&A 글을 등록한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void insertQnaCn(QnaManageVO vo) throws Exception {
+	public void insertQnaCn(QnaManageVO vo) throws Exception {
+		qnaManageMapper.insertQnaCn(vo);
+	}
 
-        insert("QnaManageDAO.insertQnaCn", vo);
-
-    }
-
-    /**
+	/**
 	 * 작성비밀번호를 확인한다.
 	 * @param vo
 	 * @return 글 총 갯수
 	 */
-    public int selectQnaPasswordConfirmCnt(QnaManageVO vo) {
-
-        return (Integer)selectOne("QnaManageDAO.selectQnaPasswordConfirmCnt", vo);
-
-    }
+	public int selectQnaPasswordConfirmCnt(QnaManageVO vo) {
+		return qnaManageMapper.selectQnaPasswordConfirmCnt(vo);
+	}
 
 	/**
 	 * Q&A 글을 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateQnaCn(QnaManageVO vo) throws Exception {
-
-        update("QnaManageDAO.updateQnaCn", vo);
-
-    }
+	public void updateQnaCn(QnaManageVO vo) throws Exception {
+		qnaManageMapper.updateQnaCn(vo);
+	}
 
 	/**
 	 * Q&A 글을 삭제한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void deleteQnaCn(QnaManageVO vo) throws Exception {
+	public void deleteQnaCn(QnaManageVO vo) throws Exception {
+		qnaManageMapper.deleteQnaCn(vo);
+	}
 
-        delete("QnaManageDAO.deleteQnaCn", vo);
-
-    }
-
-
-    /**
+	/**
 	 * Q&A 답변 글 목록에 대한 상세내용을 조회한다.
 	 * @param vo
 	 * @return 조회한 글
 	 * @exception Exception
 	 */
-    public QnaManageVO selectQnaAnswerListDetail(QnaManageVO vo) throws Exception {
+	public QnaManageVO selectQnaAnswerListDetail(QnaManageVO vo) throws Exception {
+		return qnaManageMapper.selectQnaAnswerListDetail(vo);
+	}
 
-        return (QnaManageVO) selectOne("QnaManageDAO.selectQnaAnswerListDetail", vo);
-
-    }
-
-
-    /**
+	/**
 	 * Q&A 답변 글 목록을 조회한다.
 	 * @param searchVO
 	 * @return 글 목록
 	 * @exception Exception
 	 */
 	public List<?> selectQnaAnswerList(QnaManageDefaultVO searchVO) throws Exception {
+		return qnaManageMapper.selectQnaAnswerList(searchVO);
+	}
 
-        return selectList("QnaManageDAO.selectQnaAnswerList", searchVO);
-
-    }
-
-    /**
+	/**
 	 * Q&A 답변 글 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return 글 총 갯수
 	 */
-    public int selectQnaAnswerListTotCnt(QnaManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("QnaManageDAO.selectQnaAnswerListTotCnt", searchVO);
-
-    }
+	public int selectQnaAnswerListTotCnt(QnaManageDefaultVO searchVO) {
+		return qnaManageMapper.selectQnaAnswerListTotCnt(searchVO);
+	}
 
 	/**
 	 * Q&A 답변 글을 수정한다.
 	 * @param vo
 	 * @exception Exception
 	 */
-    public void updateQnaCnAnswer(QnaManageVO vo) throws Exception {
-
-        update("QnaManageDAO.updateQnaCnAnswer", vo);
-
-    }
-
+	public void updateQnaCnAnswer(QnaManageVO vo) throws Exception {
+		qnaManageMapper.updateQnaCnAnswer(vo);
+	}
 
 }

--- a/src/main/java/egovframework/let/uss/olh/qna/service/impl/QnaManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olh/qna/service/impl/QnaManageMapper.java
@@ -1,0 +1,43 @@
+package egovframework.let.uss.olh.qna.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.olh.qna.service.QnaManageDefaultVO;
+import egovframework.let.uss.olh.qna.service.QnaManageVO;
+
+/**
+ * Q&A정보를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ */
+@EgovMapper
+public interface QnaManageMapper {
+
+	QnaManageVO selectQnaListDetail(QnaManageVO vo) throws Exception;
+
+	void updateQnaInqireCo(QnaManageVO vo) throws Exception;
+
+	List<?> selectQnaList(QnaManageDefaultVO searchVO) throws Exception;
+
+	int selectQnaListTotCnt(QnaManageDefaultVO searchVO);
+
+	void insertQnaCn(QnaManageVO vo) throws Exception;
+
+	int selectQnaPasswordConfirmCnt(QnaManageVO vo);
+
+	void updateQnaCn(QnaManageVO vo) throws Exception;
+
+	void deleteQnaCn(QnaManageVO vo) throws Exception;
+
+	QnaManageVO selectQnaAnswerListDetail(QnaManageVO vo) throws Exception;
+
+	List<?> selectQnaAnswerList(QnaManageDefaultVO searchVO) throws Exception;
+
+	int selectQnaAnswerListTotCnt(QnaManageDefaultVO searchVO);
+
+	void updateQnaCnAnswer(QnaManageVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qim/service/impl/QustnrItemManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qim/service/impl/QustnrItemManageMapper.java
@@ -1,0 +1,35 @@
+package egovframework.let.uss.olp.qim.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qim.service.QustnrItemManageVO;
+
+/**
+ * 설문항목관리를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrItemManageMapper {
+
+	List<?> selectQustnrTmplatManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+	List<?> selectQustnrItemManage(ComDefaultVO searchVO) throws Exception;
+
+	List<?> selectQustnrItemManageDetail(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+	int selectQustnrItemManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	void insertQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+	void updateQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+	void deleteQustnrRespondInfo(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+	void deleteQustnrItemManage(QustnrItemManageVO qustnrItemManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qmc/service/impl/QustnrManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qmc/service/impl/QustnrManageMapper.java
@@ -1,0 +1,43 @@
+package egovframework.let.uss.olp.qmc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qmc.service.QustnrManageVO;
+
+/**
+ * 설문관리를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrManageMapper {
+
+	List<?> selectQustnrTmplatManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	List<?> selectQustnrManage(ComDefaultVO searchVO) throws Exception;
+
+	QustnrManageVO selectQustnrManageDetailModel(QustnrManageVO qustnrManageVO) throws Exception;
+
+	List<?> selectQustnrManageDetail(QustnrManageVO qustnrManageVO) throws Exception;
+
+	int selectQustnrManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	void insertQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void updateQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void deleteQustnrRespondManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void deleteQustnrRespondInfo(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void deleteQustnrItemManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void deleteQustnrQestnManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+	void deleteQustnrManage(QustnrManageVO qustnrManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qqm/service/impl/QustnrQestnManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qqm/service/impl/QustnrQestnManageMapper.java
@@ -1,0 +1,42 @@
+package egovframework.let.uss.olp.qqm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qqm.service.QustnrQestnManageVO;
+
+/**
+ * 설문문항을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrQestnManageMapper {
+
+	List<?> selectQustnrManageStatistics2(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrManageStatistics(Map<?, ?> map) throws Exception;
+
+	Map<?, ?> selectQustnrManageQestnrSj(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrQestnManage(ComDefaultVO searchVO) throws Exception;
+
+	List<?> selectQustnrQestnManageDetail(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+	int selectQustnrQestnManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	void insertQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+	void updateQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+	void deleteQustnrRespondInfo(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+	void deleteQustnrItemManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+	void deleteQustnrQestnManage(QustnrQestnManageVO qustnrQestnManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qri/service/impl/QustnrRespondInfoMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qri/service/impl/QustnrRespondInfoMapper.java
@@ -1,0 +1,52 @@
+package egovframework.let.uss.olp.qri.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qri.service.QustnrRespondInfoVO;
+
+/**
+ * 설문조사를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrRespondInfoMapper {
+
+	List<?> selectQustnrTmplatManages(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManageStatistics1(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManageStatistics2(Map<?, ?> map) throws Exception;
+
+	Map<?, ?> selectQustnrRespondInfoManageEmplyrinfo(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManageComtnqestnrinfo(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManageComtnqustnrqesitm(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManageComtnqustnriem(Map<?, ?> map) throws Exception;
+
+	List<?> selectQustnrRespondInfoManage(ComDefaultVO searchVO) throws Exception;
+
+	int selectQustnrRespondInfoManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	List<?> selectQustnrTmplatManage(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+	void deleteQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+	void updateQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+	List<?> selectQustnrRespondInfoDetail(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+	List<?> selectQustnrRespondInfo(ComDefaultVO searchVO) throws Exception;
+
+	int selectQustnrRespondInfoCnt(ComDefaultVO searchVO) throws Exception;
+
+	void insertQustnrRespondInfo(QustnrRespondInfoVO qustnrRespondInfoVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qrm/service/impl/QustnrRespondManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qrm/service/impl/QustnrRespondManageMapper.java
@@ -1,0 +1,31 @@
+package egovframework.let.uss.olp.qrm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qrm.service.QustnrRespondManageVO;
+
+/**
+ * 설문응답자관리를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrRespondManageMapper {
+
+	List<?> selectQustnrRespondManage(ComDefaultVO searchVO) throws Exception;
+
+	List<?> selectQustnrRespondManageDetail(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+	int selectQustnrRespondManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	void insertQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+	void updateQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+	void deleteQustnrRespondManage(QustnrRespondManageVO qustnrRespondManageVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/olp/qtm/service/impl/QustnrTmplatManageMapper.java
+++ b/src/main/java/egovframework/let/uss/olp/qtm/service/impl/QustnrTmplatManageMapper.java
@@ -1,0 +1,44 @@
+package egovframework.let.uss.olp.qtm.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.olp.qtm.service.QustnrTmplatManageVO;
+
+/**
+ * 설문템플릿을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.03.20
+ * @version 1.0
+ */
+@EgovMapper
+public interface QustnrTmplatManageMapper {
+
+	Map<?, ?> selectQustnrTmplatManageTmplatImagepathnm(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	List<?> selectQustnrTmplatManage(ComDefaultVO searchVO);
+
+	List<?> selectQustnrTmplatManageDetail(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	int selectQustnrTmplatManageCnt(ComDefaultVO searchVO);
+
+	void insertQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void updateQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrRespondManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrRespondInfo(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrItemManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrQestnManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+	void deleteQustnrTmplatManage(QustnrTmplatManageVO qustnrTmplatManageVO);
+
+}

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.let.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.let.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.let.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.let.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.let.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.let.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.let.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.let.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/bnr/EgovBanner_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="bannerDAO">
+<mapper namespace="egovframework.let.uss.ion.bnr.service.impl.BannerMapper">
 
 
     <resultMap id="banner" type="egovframework.let.uss.ion.bnr.service.BannerVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FaqManageDAO">
+<mapper namespace="egovframework.let.uss.olh.faq.service.impl.FaqManageMapper">
 
 
 	<resultMap id="FaqManage" type="egovframework.let.uss.olh.faq.service.FaqManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManageDAO">
+<mapper namespace="egovframework.let.uss.olh.qna.service.impl.QnaManageMapper">
 
 
 	<resultMap id="QnaManage" type="egovframework.let.uss.olh.qna.service.QnaManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManageDAO">
+<mapper namespace="egovframework.let.uss.olh.qna.service.impl.QnaManageMapper">
 
 
 	<resultMap id="QnaManage" type="egovframework.let.uss.olh.qna.service.QnaManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManageDAO">
+<mapper namespace="egovframework.let.uss.olh.qna.service.impl.QnaManageMapper">
 
 
 	<resultMap id="QnaManage" type="egovframework.let.uss.olh.qna.service.QnaManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManageDAO">
+<mapper namespace="egovframework.let.uss.olh.qna.service.impl.QnaManageMapper">
 
 
 	<resultMap id="QnaManage" type="egovframework.let.uss.olh.qna.service.QnaManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/qna/EgovQnaManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QnaManageDAO">
+<mapper namespace="egovframework.let.uss.olh.qna.service.impl.QnaManageMapper">
 
 
 	<resultMap id="QnaManage" type="egovframework.let.uss.olh.qna.service.QnaManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.let.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.let.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.let.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.let.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.let.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.let.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.let.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.let.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qim/EgovQustnrItemManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrItemManage">
+<mapper namespace="egovframework.let.uss.olp.qim.service.impl.QustnrItemManageMapper">
 
 	<!-- 설문정보::설문템플릿정보 -->
 	<select id="selectQustnrTmplatManage" parameterType="egovframework.let.uss.olp.qim.service.QustnrItemManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.let.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 
 	<resultMap id="QustnrManage" type="egovframework.let.uss.olp.qmc.service.QustnrManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.let.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 
 	<resultMap id="QustnrManage" type="egovframework.let.uss.olp.qmc.service.QustnrManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.let.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 
 	<resultMap id="QustnrManage" type="egovframework.let.uss.olp.qmc.service.QustnrManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.let.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 
 	<resultMap id="QustnrManage" type="egovframework.let.uss.olp.qmc.service.QustnrManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qmc/EgovQustnrManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrManage">
+<mapper namespace="egovframework.let.uss.olp.qmc.service.impl.QustnrManageMapper">
 
 
 	<resultMap id="QustnrManage" type="egovframework.let.uss.olp.qmc.service.QustnrManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.let.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.let.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.let.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.let.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qqm/EgovQustnrQestnManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrQestnManage">
+<mapper namespace="egovframework.let.uss.olp.qqm.service.impl.QustnrQestnManageMapper">
 
 	<!-- 설문문항:: 객관식 통계  -->
 	<select id="selectQustnrManageStatistics" parameterType="java.util.Map" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.let.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 
 	<!-- 설문등록:: 설문템플릿조회 -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.let.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 
 	<!-- 설문등록:: 설문템플릿조회 -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.let.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 
 	<!-- 설문등록:: 설문템플릿조회 -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.let.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 
 	<!-- 설문등록:: 설문템플릿조회 -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondInfo">
+<mapper namespace="egovframework.let.uss.olp.qri.service.impl.QustnrRespondInfoMapper">
 
 
 	<!-- 설문등록:: 설문템플릿조회 -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.let.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 
 	<!-- 응답자결과(설문조사)::삭제  -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.let.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 
 	<!-- 응답자결과(설문조사)::삭제  -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.let.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 
 	<!-- 응답자결과(설문조사)::삭제  -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.let.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 
 	<!-- 응답자결과(설문조사)::삭제  -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qrm/EgovQustnrRespondManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrRespondManage">
+<mapper namespace="egovframework.let.uss.olp.qrm.service.impl.QustnrRespondManageMapper">
 
 
 	<!-- 응답자결과(설문조사)::삭제  -->

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.let.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.let.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.let.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.let.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qtm/EgovQustnrTmplatManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="QustnrTmplatManage">
+<mapper namespace="egovframework.let.uss.olp.qtm.service.impl.QustnrTmplatManageMapper">
 
 
  	<resultMap id="QustnrTmplatManageTmplatImagepathnm" type="java.util.HashMap">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,11 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: sym/ccm·mnu, uat/uia, uss/ion/bnr, uss/olh, uss/olp 12개 DAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, context-mapper.xml MapperScannerConfigurer 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 참고
- 동일 리포 다른 @EgovMapper PR과 context-mapper.xml MapperScannerConfigurer가 중복될 수 있어 선행 PR 머지 후 rebase 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
