### PR TITLE
[chore] k8s deployment·service 매니페스트 추가

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egovframe-portal-site
+  labels:
+    app: egovframe-portal-site
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: egovframe-portal-site
+  template:
+    metadata:
+      labels:
+        app: egovframe-portal-site
+    spec:
+      containers:
+        - name: egovframe-portal-site
+          image: egovframe-portal-site:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: JAVA_OPTS
+              value: "-Xms512m -Xmx1024m"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egovframe-portal-site
+  labels:
+    app: egovframe-portal-site
+spec:
+  type: NodePort
+  selector:
+    app: egovframe-portal-site
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 30061


### PR DESCRIPTION
## 변경 사유
k8s 배포용 기본 매니페스트가 없어 minikube/EKS 등 로컬·클라우드 데모 환경 구성이 번거롭습니다.

## 변경 내용
- k8s/deployment.yaml + service.yaml (NodePort 30061)

## 영향 범위
- k8s 디렉토리 신규, 기존 코드/빌드 영향 없음

## 체크리스트
- [x] 단일 주제만 다룸
