### PR TITLE
[refactor][공통컴포넌트] cmm/use·uss/sam·uss/umt DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
@@ -2,6 +2,8 @@ package egovframework.com.cmm.service.impl;
 
 import java.util.List;
 
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
@@ -23,7 +25,10 @@ import egovframework.com.cmm.service.CmmnDetailCode;
  *
  */
 @Repository("cmmUseDAO")
-public class CmmUseDAO extends EgovComAbstractDAO {
+public class CmmUseDAO {
+
+	@Resource
+	private CmmUseMapper cmmUseMapper;
 
     /**
      * 주어진 조건에 따른 공통코드를 불러온다.
@@ -33,7 +38,7 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
 	public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception {
-		return selectList("CmmUseDAO.selectCmmCodeDetail", vo);
+		return cmmUseMapper.selectCmmCodeDetail(vo);
     }
 
     /**
@@ -44,7 +49,7 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception {
-    	return selectList("CmmUseDAO.selectOgrnztIdDetail", vo);
+    	return cmmUseMapper.selectOgrnztIdDetail(vo);
     }
 
     /**
@@ -55,6 +60,6 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception {
-    	return selectList("CmmUseDAO.selectGroupIdDetail", vo);
+    	return cmmUseMapper.selectGroupIdDetail(vo);
     }
 }

--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
@@ -1,0 +1,25 @@
+package egovframework.com.cmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+
+/**
+ * 공통코드 등 전체 업무에서 공용으로 사용하는 Mapper 인터페이스
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.11
+ * @version 1.0
+ */
+@EgovMapper
+public interface CmmUseMapper {
+
+	List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception;
+
+	List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+	List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyDao.java
+++ b/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyDao.java
@@ -2,7 +2,8 @@ package egovframework.let.uss.sam.ipm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
@@ -24,7 +25,10 @@ import egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy;
  * </pre>
  */
 @Repository("onlineIndvdlInfoPolicyDao")
-public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
+public class IndvdlInfoPolicyDao {
+
+	@Resource
+	private IndvdlInfoPolicyMapper indvdlInfoPolicyMapper;
 
     /**
      * 개인정보보호정책를(을) 목록을 한다.
@@ -33,7 +37,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
 	public List<?> selectIndvdlInfoPolicyList(ComDefaultVO searchVO) throws Exception {
-        return selectList("IndvdlInfoPolicy.selectIndvdlInfoPolicy", searchVO);
+        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicy(searchVO);
     }
 
     /**
@@ -43,7 +47,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectIndvdlInfoPolicyListCnt(ComDefaultVO searchVO) throws Exception {
-        return (Integer)selectOne("IndvdlInfoPolicy.selectIndvdlInfoPolicyCnt");
+        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyCnt();
     }
 
     /**
@@ -53,7 +57,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
     public IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        return (IndvdlInfoPolicy)selectOne("IndvdlInfoPolicy.selectIndvdlInfoPolicyDetail", indvdlInfoPolicy);
+        return indvdlInfoPolicyMapper.selectIndvdlInfoPolicyDetail(indvdlInfoPolicy);
     }
 
     /**
@@ -62,7 +66,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        insert("IndvdlInfoPolicy.insertIndvdlInfoPolicy", indvdlInfoPolicy);
+        indvdlInfoPolicyMapper.insertIndvdlInfoPolicy(indvdlInfoPolicy);
     }
 
     /**
@@ -71,7 +75,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        update("IndvdlInfoPolicy.updateIndvdlInfoPolicy", indvdlInfoPolicy);
+        indvdlInfoPolicyMapper.updateIndvdlInfoPolicy(indvdlInfoPolicy);
     }
 
     /**
@@ -80,7 +84,7 @@ public class IndvdlInfoPolicyDao extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception {
-        delete("IndvdlInfoPolicy.deleteIndvdlInfoPolicy", indvdlInfoPolicy);
+        indvdlInfoPolicyMapper.deleteIndvdlInfoPolicy(indvdlInfoPolicy);
     }
 
 }

--- a/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
+++ b/src/main/java/egovframework/let/uss/sam/ipm/service/impl/IndvdlInfoPolicyMapper.java
@@ -1,0 +1,31 @@
+package egovframework.let.uss.sam.ipm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy;
+
+/**
+ * 개인정보보호정책를 처리하는 Mapper 인터페이스
+ * @author 공통서비스 장동한
+ * @since 2009.07.03
+ * @version 1.0
+ */
+@EgovMapper
+public interface IndvdlInfoPolicyMapper {
+
+	List<?> selectIndvdlInfoPolicy(ComDefaultVO searchVO) throws Exception;
+
+	int selectIndvdlInfoPolicyCnt() throws Exception;
+
+	IndvdlInfoPolicy selectIndvdlInfoPolicyDetail(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
+
+	void insertIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
+
+	void updateIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
+
+	void deleteIndvdlInfoPolicy(IndvdlInfoPolicy indvdlInfoPolicy) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/sam/stp/service/impl/StplatManageDAO.java
+++ b/src/main/java/egovframework/let/uss/sam/stp/service/impl/StplatManageDAO.java
@@ -2,7 +2,8 @@ package egovframework.let.uss.sam.stp.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.sam.stp.service.StplatManageDefaultVO;
@@ -28,8 +29,10 @@ import egovframework.let.uss.sam.stp.service.StplatManageVO;
  * </pre>
  */
 @Repository("StplatManageDAO")
-public class StplatManageDAO extends EgovAbstractMapper {
+public class StplatManageDAO {
 
+	@Resource
+	private StplatManageMapper stplatManageMapper;
 
     /**
 	 * 약관정보 글 목록에 대한 상세내용을 조회한다.
@@ -38,9 +41,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public StplatManageVO selectStplatDetail(StplatManageVO vo) throws Exception {
-
-        return (StplatManageVO) selectOne("StplatManageDAO.selectStplatDetail", vo);
-
+        return stplatManageMapper.selectStplatDetail(vo);
     }
 
     /**
@@ -50,9 +51,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public List<?> selectStplatList(StplatManageDefaultVO searchVO) throws Exception {
-
-        return selectList("StplatManageDAO.selectStplatList", searchVO);
-
+        return stplatManageMapper.selectStplatList(searchVO);
     }
 
     /**
@@ -61,9 +60,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @return 글 총 갯수
 	 */
     public int selectStplatListTotCnt(StplatManageDefaultVO searchVO) {
-
-        return (Integer)selectOne("StplatManageDAO.selectStplatListTotCnt", searchVO);
-
+        return stplatManageMapper.selectStplatListTotCnt(searchVO);
     }
 
 	/**
@@ -72,9 +69,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void insertStplatCn(StplatManageVO vo) throws Exception {
-
-        insert("StplatManageDAO.insertStplatCn", vo);
-
+        stplatManageMapper.insertStplatCn(vo);
     }
 
 	/**
@@ -83,9 +78,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void updateStplatCn(StplatManageVO vo) throws Exception {
-
-        update("StplatManageDAO.updateStplatCn", vo);
-
+        stplatManageMapper.updateStplatCn(vo);
     }
 
 	/**
@@ -94,9 +87,7 @@ public class StplatManageDAO extends EgovAbstractMapper {
 	 * @exception Exception
 	 */
     public void deleteStplatCn(StplatManageVO vo) throws Exception {
-
-        delete("StplatManageDAO.deleteStplatCn", vo);
-
+        stplatManageMapper.deleteStplatCn(vo);
     }
 
 }

--- a/src/main/java/egovframework/let/uss/sam/stp/service/impl/StplatManageMapper.java
+++ b/src/main/java/egovframework/let/uss/sam/stp/service/impl/StplatManageMapper.java
@@ -1,0 +1,31 @@
+package egovframework.let.uss.sam.stp.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.sam.stp.service.StplatManageDefaultVO;
+import egovframework.let.uss.sam.stp.service.StplatManageVO;
+
+/**
+ * 약관내용을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박정규
+ * @since 2009.04.01
+ * @version 1.0
+ */
+@EgovMapper
+public interface StplatManageMapper {
+
+	StplatManageVO selectStplatDetail(StplatManageVO vo) throws Exception;
+
+	List<?> selectStplatList(StplatManageDefaultVO searchVO) throws Exception;
+
+	int selectStplatListTotCnt(StplatManageDefaultVO searchVO);
+
+	void insertStplatCn(StplatManageVO vo) throws Exception;
+
+	void updateStplatCn(StplatManageVO vo) throws Exception;
+
+	void deleteStplatCn(StplatManageVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/MberManageDAO.java
@@ -2,7 +2,8 @@ package egovframework.let.uss.umt.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.umt.service.MberManageVO;
@@ -26,7 +27,10 @@ import egovframework.let.uss.umt.service.UserDefaultVO;
  * </pre>
  */
 @Repository("mberManageDAO")
-public class MberManageDAO extends EgovAbstractMapper{
+public class MberManageDAO {
+
+	@Resource
+	private MberManageMapper mberManageMapper;
 
     /**
      * 기 등록된 특정 일반회원의 정보를 데이터베이스에서 읽어와 화면에 출력
@@ -34,7 +38,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return List<MberManageVO> 기업회원 목록정보
      */
 	public List<MberManageVO> selectMberList(UserDefaultVO userSearchVO){
-        return selectList("mberManageDAO.selectMberList", userSearchVO);
+        return mberManageMapper.selectMberList(userSearchVO);
     }
 
     /**
@@ -43,7 +47,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return int 일반회원총갯수
      */
     public int selectMberListTotCnt(UserDefaultVO userSearchVO) {
-        return (Integer)selectOne("mberManageDAO.selectMberListTotCnt", userSearchVO);
+        return mberManageMapper.selectMberListTotCnt(userSearchVO);
     }
 
     /**
@@ -51,7 +55,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param delId 삭제 대상 일반회원아이디
      */
     public void deleteMber(String delId){
-        delete("mberManageDAO.deleteMber_S", delId);
+        mberManageMapper.deleteMber_S(delId);
     }
 
     /**
@@ -60,7 +64,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return String 등록결과
      */
     public int insertMber(MberManageVO mberManageVO){
-        return insert("mberManageDAO.insertMber_S", mberManageVO);
+        return mberManageMapper.insertMber_S(mberManageVO);
     }
 
     /**
@@ -69,7 +73,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return MberManageVO 일반회원 상세정보
      */
     public MberManageVO selectMber(String mberId){
-        return (MberManageVO) selectOne("mberManageDAO.selectMber_S", mberId);
+        return mberManageMapper.selectMber_S(mberId);
     }
 
     /**
@@ -77,7 +81,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param mberManageVO 일반회원수정정보
      */
     public void updateMber(MberManageVO mberManageVO){
-        update("mberManageDAO.updateMber_S",mberManageVO);
+        mberManageMapper.updateMber_S(mberManageVO);
     }
 
     /**
@@ -86,7 +90,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return List 일반회원약관정보
      */
 	public List<?> selectStplat(String stplatId){
-    	return selectList("mberManageDAO.selectStplat_S", stplatId);
+    	return mberManageMapper.selectStplat_S(stplatId);
     }
 
     /**
@@ -94,7 +98,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @param passVO 기업회원수정정보(비밀번호)
      */
     public void updatePassword(MberManageVO passVO) {
-        update("mberManageDAO.updatePassword_S", passVO);
+        mberManageMapper.updatePassword_S(passVO);
     }
 
     /**
@@ -103,7 +107,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return MberManageVO 일반회원 암호정보
      */
     public MberManageVO selectPassword(MberManageVO mberManageVO){
-    	return (MberManageVO) selectOne("mberManageDAO.selectPassword_S", mberManageVO);
+    	return mberManageMapper.selectPassword_S(mberManageVO);
     }
 
     /**
@@ -112,7 +116,7 @@ public class MberManageDAO extends EgovAbstractMapper{
      * @return int 사용가능여부(아이디 사용회수 )
      */
     public int checkIdDplct(String checkId){
-        return (Integer)selectOne("mberManageDAO.checkIdDplct_S", checkId);
+        return mberManageMapper.checkIdDplct_S(checkId);
     }
 
 }

--- a/src/main/java/egovframework/let/uss/umt/service/impl/MberManageMapper.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/MberManageMapper.java
@@ -1,0 +1,39 @@
+package egovframework.let.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.umt.service.MberManageVO;
+import egovframework.let.uss.umt.service.UserDefaultVO;
+
+/**
+ * 일반회원관리에 관한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ */
+@EgovMapper
+public interface MberManageMapper {
+
+	List<MberManageVO> selectMberList(UserDefaultVO userSearchVO);
+
+	int selectMberListTotCnt(UserDefaultVO userSearchVO);
+
+	void deleteMber_S(String delId);
+
+	int insertMber_S(MberManageVO mberManageVO);
+
+	MberManageVO selectMber_S(String mberId);
+
+	void updateMber_S(MberManageVO mberManageVO);
+
+	List<?> selectStplat_S(String stplatId);
+
+	void updatePassword_S(MberManageVO passVO);
+
+	MberManageVO selectPassword_S(MberManageVO mberManageVO);
+
+	int checkIdDplct_S(String checkId);
+
+}

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/ipm/EgovIndvdlInfoPolicy_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlInfoPolicy">
+<mapper namespace="egovframework.let.uss.sam.ipm.service.impl.IndvdlInfoPolicyMapper">
 
 	<!-- ::ResultMap 선언 -->
 	<resultMap id="IndvdlInfoPolicyVO" type="egovframework.let.uss.sam.ipm.service.IndvdlInfoPolicy">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManageDAO">
+<mapper namespace="egovframework.let.uss.sam.stp.service.impl.StplatManageMapper">
 
 
 	<resultMap id="StplatManage" type="egovframework.let.uss.sam.stp.service.StplatManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManageDAO">
+<mapper namespace="egovframework.let.uss.sam.stp.service.impl.StplatManageMapper">
 
 
 	<resultMap id="StplatManage" type="egovframework.let.uss.sam.stp.service.StplatManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManageDAO">
+<mapper namespace="egovframework.let.uss.sam.stp.service.impl.StplatManageMapper">
 
 
 	<resultMap id="StplatManage" type="egovframework.let.uss.sam.stp.service.StplatManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManageDAO">
+<mapper namespace="egovframework.let.uss.sam.stp.service.impl.StplatManageMapper">
 
 
 	<resultMap id="StplatManage" type="egovframework.let.uss.sam.stp.service.StplatManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="StplatManageDAO">
+<mapper namespace="egovframework.let.uss.sam.stp.service.impl.StplatManageMapper">
 
 
 	<resultMap id="StplatManage" type="egovframework.let.uss.sam.stp.service.StplatManageVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 
 
     <resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 
 
     <resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 
 
     <resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 
 
     <resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="mberManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.MberManageMapper">
 
 
     <resultMap id="stplatMap" type="egovframework.let.uss.umt.service.StplatVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,11 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.let,egovframework.com" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 @EgovMapper 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: cmm/use CmmUseDAO, uss/sam/ipm IndvdlInfoPolicyDao, uss/sam/stp StplatManageDAO, uss/umt MberManageDAO
- Mapper 인터페이스(@EgovMapper) 신규 + DAO 위임 전환 (메서드명=statement id, ServiceImpl·XML statement 무변경)
- XML namespace를 mapper FQN으로 변경, MapperScannerConfigurer 등록

## 영향 범위
- 해당 모듈만, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
