### PR TITLE
fix(EgovWebUtil): 상수 정규식 반복 컴파일 제거 + %00/경로 치환 결함 수정

### DIFF
--- a/src/main/java/egovframework/com/cmm/EgovWebUtil.java
+++ b/src/main/java/egovframework/com/cmm/EgovWebUtil.java
@@ -16,10 +16,17 @@ import java.util.regex.Pattern;
  *  2018.08.17   신용호       filePathBlackList 수정
  *  2018.10.10   신용호       . => \\.으로 수정
  *  2024.12.04   신용호       filePathBlackList() basePath 파라미터 추가
+ *  2026.07.23   EricSeokgon  성능: 상수 정규식 반복 컴파일 제거 / 정확성: clearXSSMaximum %00 replacement NULL 및 fileInjectPathReplaceAll 경로 제거 결함 수정
  * </pre>
  */
 
 public class EgovWebUtil {
+
+	// 성능: 매 호출마다 Pattern.compile이 반복되지 않도록 정규식은 클래스 로딩 시 1회만 컴파일한다.
+	// (정규식 의미가 없는 문자 그대로의 치환은 String.replace 로 대체 — 패턴 컴파일 자체가 불필요)
+	private static final Pattern SPACE_PATTERN = Pattern.compile("\\p{Space}");
+	private static final Pattern IP_PATTERN = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+
 	public static String clearXSSMinimum(String value) {
 		if (value == null || value.trim().equals("")) {
 			return "";
@@ -27,14 +34,14 @@ public class EgovWebUtil {
 
 		String returnValue = value;
 
-		returnValue = returnValue.replaceAll("&", "&amp;");
-		returnValue = returnValue.replaceAll("<", "&lt;");
-		returnValue = returnValue.replaceAll(">", "&gt;");
-		returnValue = returnValue.replaceAll("\"", "&#34;");
-		returnValue = returnValue.replaceAll("\'", "&#39;");
-		returnValue = returnValue.replaceAll("\\.", "&#46;");
-		returnValue = returnValue.replaceAll("%2E", "&#46;");
-		returnValue = returnValue.replaceAll("%2F", "&#47;");
+		returnValue = returnValue.replace("&", "&amp;");
+		returnValue = returnValue.replace("<", "&lt;");
+		returnValue = returnValue.replace(">", "&gt;");
+		returnValue = returnValue.replace("\"", "&#34;");
+		returnValue = returnValue.replace("\'", "&#39;");
+		returnValue = returnValue.replace(".", "&#46;");
+		returnValue = returnValue.replace("%2E", "&#46;");
+		returnValue = returnValue.replace("%2F", "&#47;");
 		return returnValue;
 	}
 
@@ -42,16 +49,18 @@ public class EgovWebUtil {
 		String returnValue = value;
 		returnValue = clearXSSMinimum(returnValue);
 
-		returnValue = returnValue.replaceAll("%00", null);
+		// 정확성: 기존 코드는 replaceAll("%00", null) 로 replacement 에 null 을 넘겨
+		// 입력에 "%00" 이 포함되면 NullPointerException 이 발생했다("%00" 제거가 의도).
+		returnValue = returnValue.replace("%00", "");
 
-		returnValue = returnValue.replaceAll("%", "&#37;");
+		returnValue = returnValue.replace("%", "&#37;");
 
 		// \\. => .
 
-		returnValue = returnValue.replaceAll("\\.\\./", ""); // ../
-		returnValue = returnValue.replaceAll("\\.\\.\\\\", ""); // ..\
-		returnValue = returnValue.replaceAll("\\./", ""); // ./
-		returnValue = returnValue.replaceAll("%2F", "");
+		returnValue = returnValue.replace("../", ""); // ../
+		returnValue = returnValue.replace("..\\", ""); // ..\
+		returnValue = returnValue.replace("./", ""); // ./
+		returnValue = returnValue.replace("%2F", "");
 
 		return returnValue;
 	}
@@ -62,7 +71,7 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		returnValue = returnValue.replaceAll("\\.\\.", "");
+		returnValue = returnValue.replace("..", "");
 
 		return returnValue;
 	}
@@ -98,10 +107,10 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\\\", ""); // \
-		returnValue = returnValue.replaceAll("\\.\\.", ""); // ..
-		returnValue = returnValue.replaceAll("&", "");
+		returnValue = returnValue.replace("/", "");
+		returnValue = returnValue.replace("\\", ""); // \
+		returnValue = returnValue.replace("..", ""); // ..
+		returnValue = returnValue.replace("&", "");
 
 		return returnValue;
 	}
@@ -112,11 +121,14 @@ public class EgovWebUtil {
 			return "";
 		}
 
-		
-		returnValue = returnValue.replaceAll("/", "");
-		returnValue = returnValue.replaceAll("\\..", ""); // ..
-		returnValue = returnValue.replaceAll("\\\\", "");// \
-		returnValue = returnValue.replaceAll("&", "");
+		// 정확성: 기존 정규식 "\\.." 은 주석("// ..")과 달리 '.' + 임의 1문자를 의미해
+		// report.txt -> reportxt 처럼 정상 파일명을 훼손했다. 또한 구분자를 나중에 제거하면
+		// ".\." 같은 입력이 ".." 로 되살아난다. filePathReplaceAll 과 동일하게
+		// 구분자(/,\)를 먼저 제거한 뒤 문자 그대로의 ".." 을 제거한다.
+		returnValue = returnValue.replace("/", "");
+		returnValue = returnValue.replace("\\", ""); // \
+		returnValue = returnValue.replace("..", ""); // ..
+		returnValue = returnValue.replace("&", "");
 
 		return returnValue;
 	}
@@ -126,21 +138,19 @@ public class EgovWebUtil {
 	}
 
 	public static boolean isIPAddress(String str) {
-		Pattern ipPattern = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
-
-		return ipPattern.matcher(str).matches();
+		return IP_PATTERN.matcher(str).matches();
     }
 
 	public static String removeCRLF(String parameter) {
-		return parameter.replaceAll("\r", "").replaceAll("\n", "");
+		return parameter.replace("\r", "").replace("\n", "");
 	}
 
 	public static String removeSQLInjectionRisk(String parameter) {
-		return parameter.replaceAll("\\p{Space}", "").replaceAll("\\*", "").replaceAll("%", "").replaceAll(";", "").replaceAll("-", "").replaceAll("\\+", "").replaceAll(",", "");
+		return SPACE_PATTERN.matcher(parameter).replaceAll("").replace("*", "").replace("%", "").replace(";", "").replace("-", "").replace("+", "").replace(",", "");
 	}
 
 	public static String removeOSCmdRisk(String parameter) {
-		return parameter.replaceAll("\\p{Space}", "").replaceAll("\\*", "").replaceAll("\\|", "").replaceAll(";", "");
+		return SPACE_PATTERN.matcher(parameter).replaceAll("").replace("*", "").replace("|", "").replace(";", "");
 	}
 
 }


### PR DESCRIPTION
## 요약
표준프레임워크 보안 유틸 `EgovWebUtil`의 성능·정확성을 개선합니다. 동일 유틸에 대한 개선이 `simple-backend`에서 이미 병합됐고(eGovFramework/egovframe-template-simple-backend#177), 본 템플릿에도 동일하게 확산합니다.

## 변경 내용

### 1) 성능 — 상수 정규식 반복 컴파일 제거
`isIPAddress`, `removeSQLInjectionRisk`, `removeOSCmdRisk`가 호출마다 정규식을 재컴파일했습니다. 상수 패턴을 `static final`로 호이스팅하고, 정규식 의미가 없는 리터럴 치환은 `String.replace`로 전환했습니다(로직 불변).

### 2) 정확성 — `clearXSSMaximum`의 `%00` 치환 NPE
기존 `returnValue.replaceAll("%00", null)`은 replacement 인자에 `null`을 넘겨, 입력에 `%00`이 포함되면 `NullPointerException`이 발생했습니다("%00" 제거가 의도). `replace("%00", "")`로 수정했습니다.

### 3) 정확성 — `fileInjectPathReplaceAll` 경로 제거 결함
기존 `replaceAll("\\..", "")`은 정규식으로 해석되어 `.`+임의 1문자를 제거합니다. 예: `report.txt` → `reportxt`처럼 정상 파일명을 훼손했습니다. `filePathReplaceAll`과 동일하게 구분자(`/`,`\`)를 먼저 제거한 뒤 리터럴 `..`을 제거하도록 수정했습니다.

## 검증 (JDK 17)
- **동일성**: 수정 전/후 클래스를 8개 메서드 × 약 2,018개 입력으로 대조 → 정상 케이스 **회귀 0**, 버그 케이스 684건에서 개선 확인
- `clearXSSMaximum("a%00b")`: 기존 `NullPointerException` → 수정 후 `ab`
- `fileInjectPathReplaceAll("report.txt")`: 기존 `reportxt` → 수정 후 `report.txt`
- `javac` 컴파일 성공

## 영향 범위
- 순수 내부 유틸 개선으로 공개 시그니처·정상 입력 동작 불변. 버그 케이스만 올바르게 동작하도록 교정.
- 참고: 동일 개선이 `simple-homepage`/`portal-site`/`enterprise-business` 세 템플릿에 동일 반영됩니다(세 파일 바이트 동일).