### PR TITLE
fix(EgovStringUtil): replaceChar 반복 시 StringBuffer 누적 버그 수정 (subject …

### DIFF
--- a/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovStringUtil.java
@@ -253,6 +253,7 @@ public class EgovStringUtil {
             if (srcStr.indexOf(chA) >= 0) {
                 preStr = srcStr.substring(0, srcStr.indexOf(chA));
                 nextStr = srcStr.substring(srcStr.indexOf(chA) + 1, srcStr.length());
+                rtnStr.setLength(0); // 반복 시 버퍼 누적 방지 (반복문 내 초기화)
                 srcStr = rtnStr.append(preStr).append(object).append(nextStr).toString();
             }
         }


### PR DESCRIPTION
…2자↑ 결과 손상)

replaceChar(source, subject, object)에서 rtnStr(StringBuffer)를 반복문 내에서 초기화하지 않아, subject에 source 존재 문자가 2개 이상이면 이전 반복 내용이 누적되어 결과가 손상됩니다.

예) replaceChar("a-b_c", "-_", "/") → "a/b_ca/b/c" (기대 "a/b/c")

egovframe-template-simple-backend에는 rtnStr.setLength(0) 초기화가 이미 반영돼 있어 동일하게 정합성을 맞춥니다. standalone 컴파일 전(fail)/후(pass) 검증. 단일 문자 subject는 기존과 동일 동작(회귀 없음).

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

EgovStringUtil.replaceChar(String source, String subject, String object) 1건.

- 버그: 반복문에서 공용 StringBuffer(rtnStr)를 초기화하지 않아, subject의 문자 중 source에 존재하는 것이 2개 이상이면 이전 반복 결과가 누적되어 반환값이 손상됨.
- 예: replaceChar("a-b_c", "-_", "/") → "a/b_ca/b/c" (기대 "a/b/c"); replaceChar("1:2;3,4", ":;,", "-") → 심하게 손상.
- 수정: 반복문 내 append 직전에 rtnStr.setLength(0) 추가(+1줄). egovframe-template-simple-backend에 동일 반영되어 있어 정합성을 맞춤.
- 검증(standalone javac 전/후): 다문자 subject 케이스 fail→pass, 단일 문자 subject는 기존과 동일(회귀 없음).

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
