### PR TITLE
fix(mapper): 데이터베이스 변종에 누락된 쿼리 보완

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_hsql.xml
@@ -373,4 +373,12 @@
 			AND NTT_ID = #{nttId}
  		
  	</update>
+  <select id="countArticleByAtchFileId" parameterType="egovframework.let.cop.bbs.service.BoardVO" resultType="java.lang.Integer">
+			SELECT COUNT(*) FROM LETTNBBS WHERE ATCH_FILE_ID = #{atchFileId} AND USE_AT = 'Y'
+  </select>
+
+  <select id="countArticleByAtchFileIdAndOwner" parameterType="egovframework.let.cop.bbs.service.BoardVO" resultType="java.lang.Integer">
+			SELECT COUNT(*) FROM LETTNBBS WHERE ATCH_FILE_ID = #{atchFileId} AND FRST_REGISTER_ID = #{frstRegisterId} AND USE_AT = 'Y'
+  </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olh/faq/EgovFaqManage_SQL_hsql.xml
@@ -118,4 +118,8 @@
 		
 	</delete>
 	
+  <select id="countFaqByAtchFileId" parameterType="egovframework.let.uss.olh.faq.service.FaqManageVO" resultType="java.lang.Integer">
+			SELECT COUNT(*) FROM LETTNFAQINFO WHERE ATCH_FILE_ID = #{atchFileId}
+  </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/olp/qri/EgovQustnrRespondInfo_SQL_hsql.xml
@@ -370,4 +370,8 @@
 	</insert>
 
 
+  <select id="selectFrstRegisterIdByRespondId" parameterType="egovframework.let.uss.olp.qri.service.QustnrRespondInfoVO" resultType="java.lang.String">
+			SELECT FRST_REGISTER_ID FROM LETTNQUSTNRRSPNSRESULT WHERE QUSTNR_RSPNS_RESULT_ID = #{qestnrQesrspnsId}
+  </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_altibase.xml
@@ -193,4 +193,24 @@ SELECT * FROM ( SELECT rownum rn, TB.* FROM (
         
     </select>
     
+     <select id="checkIdDplct_S" resultType="int">
+     
+         SELECT COUNT(1) usedCnt
+             FROM(
+             SELECT
+                 EMPLYR_ID             userId
+             FROM    LETTNEMPLYRINFO
+             UNION ALL
+             SELECT
+                 ENTRPRS_MBER_ID        userId
+             FROM    LETTNENTRPRSMBER
+             UNION ALL
+             SELECT
+                 MBER_ID               userId
+             FROM    LETTNGNRLMBER
+             ) A
+         WHERE userId = #{checkId}
+     
+    </select>
+
 </mapper>

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovMberManage_SQL_tibero.xml
@@ -193,4 +193,24 @@ SELECT * FROM ( SELECT rownum rn, TB.* FROM (
         
     </select>
     
+     <select id="checkIdDplct_S" resultType="int">
+     
+         SELECT COUNT(1) usedCnt
+             FROM(
+             SELECT
+                 EMPLYR_ID             userId
+             FROM    LETTNEMPLYRINFO
+             UNION ALL
+             SELECT
+                 ENTRPRS_MBER_ID        userId
+             FROM    LETTNENTRPRSMBER
+             UNION ALL
+             SELECT
+                 MBER_ID               userId
+             FROM    LETTNGNRLMBER
+             ) A
+         WHERE userId = #{checkId}
+     
+    </select>
+
 </mapper>

--- a/src/test/java/egovframework/test/EgovMapperVariantTest.java
+++ b/src/test/java/egovframework/test/EgovMapperVariantTest.java
@@ -1,0 +1,84 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 같은 매퍼의 데이터베이스별 변종은 같은 쿼리 아이디 집합을 가져야 한다.
+ *
+ * 한 변종에만 쿼리가 빠지면 그 데이터베이스에서만 화면이 실패한다.
+ *
+ * @author 최완택
+ * @since 2026-08-30
+ */
+@DisplayName("매퍼 변종")
+class EgovMapperVariantTest {
+
+	private static final Pattern FILE_NAME = Pattern
+			.compile("(.+)_(mysql|oracle|postgres|cubrid|tibero|altibase|hsql)\\.xml$");
+
+	private static final Pattern STATEMENT_ID = Pattern
+			.compile("<(?:select|insert|update|delete)\\s+id=\"([^\"]+)\"");
+
+	@Test
+	@DisplayName("데이터베이스별 변종이 같은 쿼리 아이디를 선언한다")
+	void mapperVariantsDeclareSameStatementIds() throws IOException {
+		Map<String, Map<String, Set<String>>> groups = new LinkedHashMap<>();
+
+		try (Stream<Path> paths = Files.walk(Paths.get("src/main/resources/egovframework/mapper"))) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				Matcher fileName = FILE_NAME.matcher(path.getFileName().toString());
+				if (!fileName.matches()) {
+					continue;
+				}
+				groups.computeIfAbsent(fileName.group(1), key -> new LinkedHashMap<>())
+						.put(fileName.group(2), statementIds(path));
+			}
+		}
+
+		List<String> missing = new ArrayList<>();
+
+		for (Map.Entry<String, Map<String, Set<String>>> group : groups.entrySet()) {
+			Set<String> union = new TreeSet<>();
+			group.getValue().values().forEach(union::addAll);
+
+			for (Map.Entry<String, Set<String>> variant : group.getValue().entrySet()) {
+				Set<String> gap = new TreeSet<>(union);
+				gap.removeAll(variant.getValue());
+				if (!gap.isEmpty()) {
+					missing.add(group.getKey() + "_" + variant.getKey() + ".xml " + gap);
+				}
+			}
+		}
+
+		assertTrue(missing.isEmpty(), "변종에 빠진 쿼리: " + missing);
+	}
+
+	private Set<String> statementIds(Path path) throws IOException {
+		Set<String> ids = new HashSet<>();
+		Matcher matcher = STATEMENT_ID.matcher(Files.readString(path, StandardCharsets.UTF_8));
+		while (matcher.find()) {
+			ids.add(matcher.group(1));
+		}
+		return ids;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

데이터베이스별 매퍼 변종 다섯 곳에 쿼리가 빠져 있습니다. 호출부는 조건 없이 그 쿼리를 부르므로 해당 데이터베이스에서만 실패합니다.

| 파일 | 빠진 쿼리 | 가진 변종 |
|---|---|---|
| `EgovBoard_SQL_hsql.xml` | `countArticleByAtchFileId`, `countArticleByAtchFileIdAndOwner` | mysql·oracle·cubrid·altibase·tibero |
| `EgovFaqManage_SQL_hsql.xml` | `countFaqByAtchFileId` | 〃 |
| `EgovQustnrRespondInfo_SQL_hsql.xml` | `selectFrstRegisterIdByRespondId` | 〃 |
| `EgovMberManage_SQL_altibase.xml` | `checkIdDplct_S` | mysql·oracle·cubrid·hsql |
| `EgovMberManage_SQL_tibero.xml` | `checkIdDplct_S` | 〃 |

앞의 세 파일이 빠뜨린 쿼리는 첨부파일 접근 권한을 판정하는 경로에서 쓰입니다.

```java
// EgovFileAuthorizer.java:47, :51
int faqLinkedCount = faqManageDAO.countFaqByAtchFileId(atchFileId);
int bbsLinkedCount = bbsManageDAO.countArticleByAtchFileId(atchFileId);
```

`checkIdDplct_S`는 회원 가입 아이디 중복확인에서 쓰입니다.

```java
// EgovMberManageController.java:531
int usedCnt = mberManageService.checkIdDplct(checkId);
```

각 변종에 같은 쿼리를 채웠습니다. 옮긴 구문은 표준 SQL이라 방언 차이가 없습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

매퍼의 데이터베이스별 변종끼리 같은 쿼리 아이디를 선언하는지 확인하는 테스트를 추가했습니다.

수정 전

```
[ERROR] EgovMapperVariantTest.mapperVariantsDeclareSameStatementIds
        변종에 빠진 쿼리: [EgovQustnrRespondInfo_SQL_hsql.xml [selectFrstRegisterIdByRespondId], ...]
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다. `-DskipTests=false`로는 덮어써지지 않습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 데이터베이스 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.

