### PR TITLE
fix(mapper): 알티베이스 매퍼의 iBATIS 파라미터 표기를 MyBatis 표기로 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -92,7 +92,7 @@
 			 FRST_REGISTER_ID, FRST_REGIST_PNTTM, USE_AT
 			 )
 			VALUES
-			( #{nttId}, #{bbsId}, #{nttSj}, #nttCn:CLOB#, #{nttNo}, 
+			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{nttNo}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
 			  #{parnts}, 1, #{replyLc}, #{atchFileId},
@@ -115,7 +115,7 @@
 			 FRST_REGISTER_ID, FRST_REGIST_PNTTM, USE_AT
 			 )
 			VALUES
-			( #{nttId}, #{bbsId}, #{nttSj}, #nttCn:CLOB#, #{sortOrdr}, 
+			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{sortOrdr}, 
 			  #{ntcrId}, #{ntcrNm}, #{password}, #{inqireCo}, 
 			  #{ntceBgnde}, #{ntceEndde}, #{replyAt}, 
 			  #{parnts}, 1, #{replyLc}, #{atchFileId},
@@ -229,7 +229,7 @@
  		
 			UPDATE LETTNBBS SET 
 				NTT_SJ = #{nttSj},
-				NTT_CN = #nttCn:CLOB#, 
+				NTT_CN = #{nttCn}, 
 				NTCR_ID = #{ntcrId},
 				NTCR_NM = #{ntcrNm},
 				PASSWORD = #{password},

--- a/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/sam/stp/EgovStplatManage_SQL_altibase.xml
@@ -92,8 +92,8 @@
 				  , LAST_UPDUSR_ID) 
 			VALUES ( #{useStplatId}
 				  , #{useStplatNm}			
-				  , #useStplatCn:CLOB#
-				  , #infoProvdAgreCn:CLOB#
+				  , #{useStplatCn}
+				  , #{infoProvdAgreCn}
 				  , sysdate
 				  , #{frstRegisterId}
 				  , sysdate
@@ -105,8 +105,8 @@
 		
 			UPDATE	LETTNSTPLATINFO	SET 
 				   	USE_STPLAT_NM=#{useStplatNm}
-				  ,	USE_STPLAT_CN=#useStplatCn:CLOB#				  
-				  ,	INFO_PROVD_AGRE_CN=#infoProvdAgreCn:CLOB#
+				  ,	USE_STPLAT_CN=#{useStplatCn}				  
+				  ,	INFO_PROVD_AGRE_CN=#{infoProvdAgreCn}
 				  , LAST_UPDT_PNTTM=sysdate
 				  , LAST_UPDUSR_ID=#{lastUpdusrId}
  			WHERE  USE_STPLAT_ID=#{useStplatId}

--- a/src/test/java/egovframework/test/EgovMapperParameterSyntaxTest.java
+++ b/src/test/java/egovframework/test/EgovMapperParameterSyntaxTest.java
@@ -1,0 +1,53 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 매퍼는 MyBatis 파라미터 표기만 쓴다.
+ *
+ * iBATIS 2 표기 {@code #name:TYPE#}는 MyBatis에서 파라미터로 해석되지 않고
+ * 문장에 그대로 남는다.
+ *
+ * @author 최완택
+ * @since 2026-08-30
+ */
+@DisplayName("매퍼 파라미터 표기")
+class EgovMapperParameterSyntaxTest {
+
+	private static final Pattern LEGACY_PARAMETER = Pattern.compile("#[A-Za-z_][A-Za-z0-9_]*(?::[A-Z]+)?#");
+
+	@Test
+	@DisplayName("iBATIS 표기를 쓰지 않는다")
+	void mappersUseMyBatisParameterSyntax() throws IOException {
+		List<String> found = new ArrayList<>();
+
+		try (Stream<Path> paths = Files.walk(Paths.get("src/main/resources/egovframework/mapper"))) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				if (!path.getFileName().toString().endsWith(".xml")) {
+					continue;
+				}
+				Matcher matcher = LEGACY_PARAMETER.matcher(Files.readString(path, StandardCharsets.UTF_8));
+				while (matcher.find()) {
+					found.add(path.getFileName() + " " + matcher.group());
+				}
+			}
+		}
+
+		assertTrue(found.isEmpty(), "iBATIS 표기: " + found);
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

알티베이스 매퍼 두 개에 iBATIS 표기 `#name:CLOB#`가 남아 있습니다. MyBatis는 이 표기를 파라미터로 해석하지 않고 문장에 그대로 둡니다.

```xml
<!-- EgovBoard_SQL_altibase.xml:95 -->
( #{nttId}, #{bbsId}, #{nttSj}, #nttCn:CLOB#, #{nttNo}, ...
```

같은 파일의 조회 쪽은 MyBatis 표기를 씁니다.

```xml
<!-- EgovBoard_SQL_altibase.xml:31 -->
<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
```

나머지 변종(mysql·oracle·cubrid·tibero·hsql)은 같은 컬럼을 `#{nttCn}`으로 바인딩합니다.

AS-IS / TO-BE

```diff
-			( #{nttId}, #{bbsId}, #{nttSj}, #nttCn:CLOB#, #{nttNo},
+			( #{nttId}, #{bbsId}, #{nttSj}, #{nttCn}, #{nttNo},
```

대상은 일곱 곳입니다.

| 파일 | 컬럼 |
|---|---|
| `EgovBoard_SQL_altibase.xml` | `nttCn` (3) |
| `EgovStplatManage_SQL_altibase.xml` | `useStplatCn`, `infoProvdAgreCn` (4) |

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

매퍼가 iBATIS 표기를 쓰지 않는지 확인하는 테스트를 추가했습니다.

수정 전

```
[ERROR] EgovMapperParameterSyntaxTest.mappersUseMyBatisParameterSyntax
        iBATIS 표기: [EgovStplatManage_SQL_altibase.xml #useStplatCn:CLOB#, ... 7건]
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다. `-DskipTests=false`로는 덮어써지지 않습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

알티베이스 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.

