### PR TITLE
fix(cop): 게시판 속성정보 ByTrget 핸들러에 @Valid 누락으로 검증 분기가 동작하지 않음

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageController.java
+++ b/src/main/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageController.java
@@ -351,7 +351,7 @@ public class EgovBBSAttributeManageController {
 	 */
 	@RequestMapping(value = "/cop/bbs/insertBdMstrByTrget.do", method = RequestMethod.POST)
 	public String insertBdMstrByTrget(@ModelAttribute("searchVO") BoardMasterVO boardMasterVO,
-			@ModelAttribute("boardMaster") BoardMaster boardMaster,
+			@Valid @ModelAttribute("boardMaster") BoardMaster boardMaster,
 			BindingResult bindingResult, SessionStatus status,
 			ModelMap model) throws Exception {
 
@@ -475,7 +475,7 @@ public class EgovBBSAttributeManageController {
 	 */
 	@RequestMapping(value = "/cop/bbs/UpdateBBSMasterInfByTrget.do", method = RequestMethod.POST)
 	public String updateBBSMasterInfByTrget(@ModelAttribute("searchVO") BoardMasterVO boardMasterVO,
-		@ModelAttribute("boardMaster") BoardMaster boardMaster,
+		@Valid @ModelAttribute("boardMaster") BoardMaster boardMaster,
 		BindingResult bindingResult, ModelMap model) throws Exception {
 
 		checkAuthority(boardMasterVO); // server-side 권한 확인


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBBSAttributeManageController`에서 `BindingResult`를 받는 핸들러는 넷입니다. 이 중 둘에만 `@Valid`가 붙어 있습니다.

| 핸들러 | `@Valid` | `bindingResult.hasErrors()` 분기 |
|---|---|---|
| `insertBBSMasterInf` (121행) | 있음 | 동작 |
| `updateBBSMasterInf` (241행) | 있음 | 동작 |
| `insertBdMstrByTrget` (353행) | 없음 | 실행되지 않음 |
| `updateBBSMasterInfByTrget` (477행) | 없음 | 실행되지 않음 |

`@Valid`가 없으면 `BoardMaster`의 제약(`@EgovNullCheck` 7개, `@Size` 2개)이 적용되지 않아 `BindingResult`가 항상 비어 있습니다. 뒤의 두 핸들러는 검증 분기를 두고도 그 분기로 들어가지 못하고 필수값이 빈 요청이 그대로 저장됩니다.

앞의 두 핸들러와 같게 `@Valid`를 붙였습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

HSQL 인메모리로 기동하고 관리자로 로그인한 뒤, 필수값을 비운 요청을 `UpdateBBSMasterInfByTrget.do`에 보내고 게시판 이름이 어떻게 되는지 확인했습니다.

```
curl -b jar --data-urlencode "bbsId=BBSMSTR_CCCCCCCCCCCC" \
     --data-urlencode "bbsNm=" --data-urlencode "bbsTyCode=" \
     --data-urlencode "bbsAttrbCode=" --data-urlencode "replyPosblAt=" \
     --data-urlencode "fileAtchPosblAt=" --data-urlencode "tmplatId=" \
     --data-urlencode "_csrf=$TOKEN" \
     http://localhost:8099/cop/bbs/UpdateBBSMasterInfByTrget.do
```

수정 전

```
BEFORE: bbsNm='자료실'
AFTER : bbsNm=''
```

수정 후

```
BEFORE: bbsNm='자료실'
AFTER : bbsNm='자료실'
```

필수값을 채운 정상 요청은 수정 후에도 그대로 반영됩니다(`자료실` → `자료실-수정됨` → `자료실`).

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보내 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 요청과 결과 값으로 대신합니다.
