### PR TITLE
RenewPaginationRenderer 의 로그가 다른 클래스 이름으로 기록되는 문제 수정 (Bind RenewPaginationRenderer's logger to its own class)

### DIFF
--- a/src/main/java/egovframework/com/cmm/RenewPaginationRenderer.java
+++ b/src/main/java/egovframework/com/cmm/RenewPaginationRenderer.java
@@ -26,7 +26,7 @@ import jakarta.servlet.ServletContext;
  */
 public class RenewPaginationRenderer extends AbstractPaginationRenderer implements ServletContextAware{
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(ImagePaginationRenderer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(RenewPaginationRenderer.class);
 
 	private ServletContext servletContext;
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`RenewPaginationRenderer` 가 로거를 형제 클래스 이름으로 잡고 있습니다.

```java
// RenewPaginationRenderer.java:29
private static final Logger LOGGER = LoggerFactory.getLogger(ImagePaginationRenderer.class);
```

이 로거는 같은 파일 38·39행에서 실제로 쓰입니다.

```java
if (LOGGER.isDebugEnabled()) {
    LOGGER.debug("getContextPath={}", servletContext.getContextPath());
}
```

그래서 이 클래스가 남긴 로그가 `ImagePaginationRenderer` 이름으로 나갑니다. 로그를 보고 어느 렌더러가 동작했는지 구분할 수 없고, 이 클래스만 레벨을 조절하려 해도 형제 이름으로 설정해야 합니다. 형제인 `ImagePaginationRenderer` 는 자기 클래스를 올바로 넘깁니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src` 전체에서 손으로 쓴 `LoggerFactory.getLogger(X.class)` 를 뽑아 감싸는 클래스와 대조했습니다. 수정 전 29곳 중 어긋난 곳은 이 한 곳이었고, 수정 뒤 0곳입니다.

```
수정 전  correct: 28  MISMATCHED: 1
        RenewPaginationRenderer.java:29  class RenewPaginationRenderer -> getLogger(ImagePaginationRenderer.class)
수정 후  correct: 29  MISMATCHED: 0
```

대조 스크립트가 실제로 잡아내는지 확인하려고, 올바른 파일 하나를 복사해 로거를 다른 클래스로 바꿔 넣고 다시 돌렸습니다. `MISMATCHED: 1` 로 잡혔습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

화면 동작이 아니라 로그에 남는 클래스 이름이 달라집니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전후로 달라지는 것은 위 대조 결과의 한 줄입니다.
