### PR TITLE
README Quickstart 가 상류 대신 개인 포크를 클론하도록 안내하는 문제 수정 (Point the README Quickstart clone URL at this repository)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,13 @@
 ## Quickstart
 
 ```bash
-# 1) Clone (your fork)
-git clone https://github.com/gogoleelee88/egovframe-portal-site-template.git
+# 1) Clone
+git clone https://github.com/eGovFramework/egovframe-portal-site-template.git
 cd egovframe-portal-site-template
 
 # 2) Build
 mvn clean package
 
 # 3) Run (예: 임베디드 톰캣/와스 환경에 맞게)
-# mvn spring-boot:run  # (spring-boot 사용 시)
-# 또는 IDE에서 서버 실행 후 http://localhost:8080 접속
-
+# 생성된 WAR 를 WAS 에 배포하거나, IDE 에서 서버 실행 후 http://localhost:8080 접속
+```


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

README 의 Quickstart 가 이 저장소가 아니라 개인 포크를 클론하라고 안내합니다.

```bash
# 1) Clone (your fork)
git clone https://github.com/gogoleelee88/egovframe-portal-site-template.git
```

주석은 "your fork" 라고 적혀 있지만 URL 은 특정 개인 포크로 고정돼 있습니다. 그 포크의 `main` 은 `164bf48` 에 멈춰 있고, 이 저장소의 `main` 보다 80커밋 뒤처집니다. 5.0.0 릴리스 이전 스냅샷이라 README 가 같은 문서에서 표로 안내하는 환경과 다른 코드를 받게 됩니다.

같은 블록의 두 가지도 함께 정리했습니다.

`# mvn spring-boot:run` 안내는 이 프로젝트에 맞지 않습니다. `pom.xml:8` 이 `<packaging>war</packaging>` 이고 spring-boot 의존성이 없습니다. WAR 배포 또는 IDE 서버 실행 안내만 남겼습니다.

`Quickstart` 의 ```` ```bash ```` 코드펜스가 닫히지 않아 문서에 펜스가 하나뿐이었습니다. 닫는 펜스를 넣었습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

포크의 현재 위치와 커밋 격차를 실제로 조회해 확인했습니다.

```
$ git ls-remote https://github.com/gogoleelee88/egovframe-portal-site-template.git refs/heads/main
164bf48ca6ad0069b7966498bf8f43b458adfca3	refs/heads/main

$ git rev-list --count 164bf48..origin/main
80
```

저장소 안에서 상류가 아닌 클론 URL 을 안내하는 곳은 이 한 곳뿐입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

문서 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

바뀌는 것은 위 코드 블록의 클론 URL 과 실행 안내 한 줄입니다.
