### PR TITLE
FAQ·Q&A 관리 화면이 사용자 네임스페이스로 제출하는 문제 수정 (Submit admin screens to the admin namespace)

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/uss/olh/faq/admin/EgovFaqCnUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/faq/admin/EgovFaqCnUpdt.jsp
@@ -72,7 +72,7 @@ function fn_egov_updt_faqcn(form, faqId){
 		if(confirm('<spring:message code="common.update.msg" />')) {
 			
 			// form.faqId.value = faqId; 주석처리
-			form.action = "<c:url value='/uss/olh/faq/FaqCnUpdt.do'/>";
+			form.action = "<c:url value='/uss/olh/faq/admin/FaqCnUpdt.do'/>";
 			form.submit();
 		}
 	}

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/faq/admin/EgovFaqDetailInqire.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/faq/admin/EgovFaqDetailInqire.jsp
@@ -64,7 +64,7 @@ function fn_egov_delete_faq(faqId){
 	if	(confirm('<spring:message code="common.delete.msg" />')) {
 		// Delete하기 위한 키값(faqId)을 셋팅
 		document.FaqManageForm.faqId.value = faqId;	
-		document.FaqManageForm.action = "<c:url value='/uss/olh/faq/FaqCnDelete.do'/>";
+		document.FaqManageForm.action = "<c:url value='/uss/olh/faq/admin/FaqCnDelete.do'/>";
 		document.FaqManageForm.submit();
 	}
 }

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaAnswerDetailInqire.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaAnswerDetailInqire.jsp
@@ -38,7 +38,7 @@
  ******************************************************** */
 function fn_egov_inqire_qnaanswerlist() {
 
-	document.QnaManageForm.action = "<c:url value='/uss/olh/qnm/QnaAnswerListInqire.do'/>";
+	document.QnaManageForm.action = "<c:url value='/uss/olh/qnm/admin/QnaAnswerListInqire.do'/>";
 	document.QnaManageForm.submit();
 		
 }
@@ -51,7 +51,7 @@ function fn_egov_updt_qnacnanswer(qaId){
 	// Update하기 위한 키값을 셋팅
 	document.QnaManageForm.qaId.value = qaId;	
 
-	document.QnaManageForm.action = "<c:url value='/uss/olh/qnm/QnaCnAnswerUpdtView.do'/>";
+	document.QnaManageForm.action = "<c:url value='/uss/olh/qnm/admin/QnaCnAnswerUpdtView.do'/>";
 	document.QnaManageForm.submit();	
 
 		

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaAnswerListInqire.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaAnswerListInqire.jsp
@@ -50,7 +50,7 @@ function fn_egov_initl_qnaanswerlist(){
 function fn_egov_select_linkPage(pageNo){
 	
 	document.QnaAnswerListForm.pageIndex.value = pageNo;
-	document.QnaAnswerListForm.action = "<c:url value='/uss/olh/qnm/QnaAnswerListInqire.do'/>";
+	document.QnaAnswerListForm.action = "<c:url value='/uss/olh/qnm/admin/QnaAnswerListInqire.do'/>";
    	document.QnaAnswerListForm.submit();
    	
 }
@@ -82,7 +82,7 @@ function fn_egov_inquire_qnaanswerdetail(qaId) {
 
 	// Q&A ID 셋팅.
 	document.QnaAnswerListForm.qaId.value = qaId;	
-    document.QnaAnswerListForm.action = "<c:url value='/uss/olh/qnm/QnaAnswerDetailInqire.do'/>"; 
+    document.QnaAnswerListForm.action = "<c:url value='/uss/olh/qnm/admin/QnaAnswerDetailInqire.do'/>"; 
   	document.QnaAnswerListForm.submit();	
 	   	   		
 }

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnAnswerUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnAnswerUpdt.jsp
@@ -66,7 +66,7 @@ function fn_egov_updt_qnacnanswer(form, qaId){
 
 	
 		form.qaId.value = qaId;
-		form.action = "<c:url value='/uss/olh/qnm/QnaCnAnswerUpdt.do'/>";
+		form.action = "<c:url value='/uss/olh/qnm/admin/QnaCnAnswerUpdt.do'/>";
 		form.submit();	
 				
 	}
@@ -78,7 +78,7 @@ function fn_egov_updt_qnacnanswer(form, qaId){
  ******************************************************** */
 function fn_egov_inqire_qnaanswerlist() {
 
-	qnaManageVO.action = "<c:url value='/uss/olh/qnm/QnaAnswerListInqire.do'/>";
+	qnaManageVO.action = "<c:url value='/uss/olh/qnm/admin/QnaAnswerListInqire.do'/>";
 	qnaManageVO.submit();
 		
 }

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnRegist.jsp
@@ -57,7 +57,7 @@ function fn_egov_initl_qnacn(){
 		
 		if(confirm('<spring:message code="common.regist.msg" />')) {
 			
-			form.action = "<c:url value='/uss/olh/qna/QnaCnRegist.do'/>";
+			form.action = "<c:url value='/uss/olh/qna/admin/QnaCnRegist.do'/>";
 			form.submit();
 		}
 	}

--- a/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/uss/olh/qna/admin/EgovQnaCnUpdt.jsp
@@ -57,7 +57,7 @@ function fn_egov_initl_qnacn(){
 			if(confirm('<spring:message code="common.update.msg" />')) {
 				
 				form.qaId.value = qaId;
-				form.action = "<c:url value='/uss/olh/qna/QnaCnUpdt.do'/>";
+				form.action = "<c:url value='/uss/olh/qna/admin/QnaCnUpdt.do'/>";
 				form.submit();
 			}
 		}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

FAQ·Q&A 관리 화면에서 저장·삭제·목록 버튼을 누르면 사용자용 URL 로 제출됩니다. 관리자가 FAQ 내용을 고치고 저장하면 관리 목록이 아니라 공개 FAQ 목록으로 나갑니다.

같은 파일이 관리자 URL 과 사용자 URL 을 동시에 갖고 있습니다. `EgovFaqCnUpdt.jsp` 를 예로 들면 `<form:form action="…/uss/olh/faq/admin/FaqCnUpdt.do" onsubmit="return false">` 로 선언돼 있지만, 네이티브 제출이 막혀 있어 실제 제출은 저장 버튼 핸들러가 합니다.

```javascript
// 저장 버튼: onclick="fn_egov_updt_faqcn(document.faqManageVO, …)"
form.action = "<c:url value='/uss/olh/faq/FaqCnUpdt.do'/>";   // /admin/ 이 빠져 있다
form.submit();
```

`/uss/olh/faq/FaqCnUpdt.do` 는 `EgovFaqManageController` 가 받고 `forward:/uss/olh/faq/FaqListInqire.do` 로 나갑니다. 관리자용 `/uss/olh/faq/admin/FaqCnUpdt.do` 는 `EgovFaqAdminManageController` 에 따로 있습니다.

사용자용 사본 `uss/olh/faq/EgovFaqCnUpdt.jsp` 는 같은 자리가 전부 사용자 URL 로 일관돼 있습니다. 관리자 사본을 만들 때 네임스페이스 치환이 일부만 적용된 것으로 보입니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`/admin/` 아래 JSP 전체에서 자바스크립트가 설정하는 `action` 을 뽑고, 각각에 대응하는 `/admin/` 매핑이 컨트롤러에 실재하는지 대조했습니다. 주석 블록은 제외했습니다.

```
수정 전  admin JSP 가 non-admin 으로 제출: 12곳
         그중 /admin/ 매핑이 실재:        10곳  ← 수정 대상
         대응 매핑 없음:                   2곳  (QnaAnswerCnRegistView, addScrap)
수정 후  남은 곳: 0
```

10곳이 실제로 실행되는지도 확인했습니다. 아홉은 같은 파일의 `onclick` 에 걸려 있고, 나머지 하나(`fn_egov_select_linkPage`)는 `<ui:pagination … jsFunction="fn_egov_select_linkPage" />` 가 부릅니다.

대응 매핑이 없는 2곳은 바꾸지 않았습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [X] 기타 Others

제출 대상 URL 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

바뀌는 것은 각 파일에서 `action` 에 들어가는 경로 한 줄씩입니다.
