### PR TITLE
build(pom): 웹 설정 부모를 5.0.1로 업데이트

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
 	<groupId>egovframework</groupId>
 	<artifactId>egovframe-template-portal</artifactId>
 	<packaging>war</packaging>
-	<version>5.0.0</version>
 	<name>egovframe-template-portal</name>
 	<url>http://www.egovframe.go.kr</url>
 
@@ -21,7 +20,7 @@
 	<parent>
 		<groupId>org.egovframe.web</groupId>
 		<artifactId>egovframe-web-config-parent</artifactId>
-		<version>5.0.0</version>
+		<version>5.0.1</version>
 	</parent>
 
 	<repositories>
@@ -51,13 +50,8 @@
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<log4j2.version>2.25.3</log4j2.version>
-		<slf4j.version>2.0.17</slf4j.version>
-		<commons-beanutils.version>1.11.0</commons-beanutils.version>
 		<protobuf.java.version>3.25.5</protobuf.java.version>
-		<parsson.version>1.1.7</parsson.version>
 		<hikaricp.version>6.3.3</hikaricp.version>
-		<jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
 	</properties>
 
 	<dependencies>
@@ -81,7 +75,6 @@
 		<dependency>
 			<groupId>org.egovframe.rte</groupId>
 			<artifactId>egovframe-rte-fdl-security</artifactId>
-			<version>5.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.egovframe.rte</groupId>
@@ -130,27 +123,22 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>${log4j2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>${log4j2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.log4jdbc</groupId>
@@ -167,7 +155,6 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>${commons-beanutils.version}</version>
 		</dependency>
 
 		<dependency>
@@ -193,7 +180,6 @@
 		<dependency>
 			<groupId>org.eclipse.parsson</groupId>
 			<artifactId>parsson</artifactId>
-			<version>${parsson.version}</version>
 		</dependency>
 
 		<dependency>
@@ -258,7 +244,6 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>2.7.4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

전자정부 표준프레임워크 웹 설정 부모 POM을 5.0.1로 업데이트하고,
부모 POM에서 관리하는 프로젝트 및 의존성 버전을 상속하도록 설정을 정리합니다.

## 주요 변경 사항

- `egovframe-web-config-parent` 버전을 5.0.0에서 5.0.1로 업데이트
- 프로젝트 버전 `5.0.0` 직접 선언을 제거하고 부모 POM의 `5.0.1` 버전을 상속
- 부모 POM에서 관리하는 다음 버전 속성 제거
  - Log4j2
  - SLF4J
  - Commons BeanUtils
  - Parsson
  - Jakarta Servlet API
- 부모 POM과 중복되는 개별 의존성 버전 선언 제거
  - `egovframe-rte-fdl-security`
  - Log4j2 및 SLF4J 관련 의존성
  - Commons BeanUtils
  - Parsson
  - HSQLDB
- 프로젝트에서 별도로 관리할 필요가 있는 HikariCP 및 Protobuf 버전은 기존 선언 유지

## 변경 효과

- 공통 의존성 버전을 웹 설정 부모 POM 5.0.1에서 일관되게 관리
- 프로젝트 POM의 중복 설정 감소
- 프로젝트 산출물 버전을 부모 버전과 동일한 5.0.1로 정렬

## 검증

- `git diff --check` 통과
- JDK 17.0.17 및 Maven 3.9.9 환경에서 `mvn validate` 성공
- Maven이 프로젝트 버전을 `5.0.1`, 패키징을 `war`로 정상 인식하는 것을 확인

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

http://localhost:8080/egovframe-template-portal

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
